### PR TITLE
Fix bad positioning

### DIFF
--- a/asktext.py
+++ b/asktext.py
@@ -488,7 +488,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             self.global_scale_factor = self._scale_adj.get_value()
 
             try:
-                self.callback(self.text, self.preamble_file, self.global_scale_factor)
+                self.callback(self.text, self.preamble_file, self.global_scale_factor,self._alignment_combobox.get_active_text())
             except StandardError, error:
                 import traceback
 
@@ -629,10 +629,28 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             scale_box = gtk.HBox(homogeneous=False, spacing=2)
             scale_frame.add(scale_box)
             self._scale_adj = gtk.Adjustment(lower=0.1, upper=10, step_incr=0.1, page_incr=1)
-            self._scale = gtk.HScale(self._scale_adj)
+            self._scale = gtk.SpinButton(self._scale_adj)
             self._scale.set_digits(1)
             self._scale_adj.set_value(self.scale_factor_after_loading())
             self._scale.set_tooltip_text("Change the scale of the LaTeX output")
+
+            liststore = gtk.ListStore(str)
+            for a in [  "top left","top center","top right",
+                        "middle left","middle center","middle right",
+                        "bottom left","bottom center", "bottom right"]:
+                liststore.append([a])
+
+
+            self._alignment_combobox = gtk.ComboBox()
+
+            cell = gtk.CellRendererText()
+            self._alignment_combobox.pack_start(cell)
+            self._alignment_combobox.add_attribute(cell, 'text', 0)
+            self._alignment_combobox.set_model(liststore)
+            self._alignment_combobox.set_wrap_width(3)
+            self._alignment_combobox.set_active(4)
+
+
 
             # We need buttons with custom labels and stock icons, so we make some
             reset_scale = self.current_scale_factor if self.current_scale_factor else self.global_scale_factor
@@ -667,6 +685,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             scale_global_button.connect('clicked', self.use_global_scale_factor)
 
             scale_box.pack_start(self._scale, True, True, 2)
+            scale_box.pack_start(self._alignment_combobox, True, True, 2)
             scale_box.pack_start(scale_reset_button, False, False, 2)
             scale_box.pack_start(scale_global_button, False, False, 2)
 

--- a/asktext.py
+++ b/asktext.py
@@ -628,9 +628,9 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             scale_frame = gtk.Frame("Scale Factor")
             scale_box = gtk.HBox(homogeneous=False, spacing=2)
             scale_frame.add(scale_box)
-            self._scale_adj = gtk.Adjustment(lower=0.1, upper=10, step_incr=0.1, page_incr=1)
+            self._scale_adj = gtk.Adjustment(lower=0.001, upper=180, step_incr=0.001, page_incr=1)
             self._scale = gtk.SpinButton(self._scale_adj)
-            self._scale.set_digits(1)
+            self._scale.set_digits(3)
             self._scale_adj.set_value(self.scale_factor_after_loading())
             self._scale.set_tooltip_text("Change the scale of the LaTeX output")
 

--- a/asktext.py
+++ b/asktext.py
@@ -116,7 +116,7 @@ def error_dialog(parent, title, message, detailed_message=None):
 
 
 class AskerFactory(object):
-    def asker(self, text, preamble_file, global_scale_factor, current_scale_factor):
+    def asker(self, text, preamble_file, global_scale_factor, current_scale_factor, current_alignment):
         """
         Return the best possible GUI variant depending on the installed components
         :param current_scale_factor:
@@ -127,15 +127,15 @@ class AskerFactory(object):
         :return: an instance of AskText
         """
         if TOOLKIT == TK:
-            return AskTextTK(text, preamble_file, global_scale_factor, current_scale_factor)
+            return AskTextTK(text, preamble_file, global_scale_factor, current_scale_factor, current_alignment)
         elif TOOLKIT in (GTK, GTKSOURCEVIEW):
-            return AskTextGTKSource(text, preamble_file, global_scale_factor, current_scale_factor)
+            return AskTextGTKSource(text, preamble_file, global_scale_factor, current_scale_factor, current_alignment)
 
 
 class AskText(object):
     """GUI for editing TexText objects"""
 
-    def __init__(self, text, preamble_file, global_scale_factor, current_scale_factor):
+    def __init__(self, text, preamble_file, global_scale_factor, current_scale_factor, current_alignment):
         if len(text) > 0:
             self.text = text
         else:
@@ -147,6 +147,7 @@ class AskText(object):
         self.callback = None
         self.global_scale_factor = global_scale_factor
         self.current_scale_factor = current_scale_factor
+        self.current_alignment = current_alignment
         self.preamble_file = preamble_file
         self._preamble_widget = None
         self._scale = None
@@ -192,8 +193,8 @@ if TOOLKIT == TK:
     class AskTextTK(AskText):
         """TK GUI for editing TexText objects"""
 
-        def __init__(self, text, preamble_file, global_scale_factor, current_scale_factor):
-            super(AskTextTK, self).__init__(text, preamble_file, global_scale_factor, current_scale_factor)
+        def __init__(self, text, preamble_file, global_scale_factor, current_scale_factor, current_alignment):
+            super(AskTextTK, self).__init__(text, preamble_file, global_scale_factor, current_scale_factor, current_alignment)
             self._frame = None
             self._scale = None
 
@@ -289,8 +290,8 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
     class AskTextGTKSource(AskText):
         """GTK + Source Highlighting for editing TexText objects"""
 
-        def __init__(self, text, preamble_file, global_scale_factor, current_scale_factor):
-            super(AskTextGTKSource, self).__init__(text, preamble_file, global_scale_factor, current_scale_factor)
+        def __init__(self, text, preamble_file, global_scale_factor, current_scale_factor, current_alignment):
+            super(AskTextGTKSource, self).__init__(text, preamble_file, global_scale_factor, current_scale_factor, current_alignment)
             self._preview = None
             self._scale_adj = None
             self._preview_callback = None
@@ -635,9 +636,10 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             self._scale.set_tooltip_text("Change the scale of the LaTeX output")
 
             liststore = gtk.ListStore(str)
-            for a in [  "top left","top center","top right",
+            alignment_labels = [  "top left","top center","top right",
                         "middle left","middle center","middle right",
-                        "bottom left","bottom center", "bottom right"]:
+                        "bottom left","bottom center", "bottom right"]
+            for a in alignment_labels:
                 liststore.append([a])
 
 
@@ -648,7 +650,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             self._alignment_combobox.add_attribute(cell, 'text', 0)
             self._alignment_combobox.set_model(liststore)
             self._alignment_combobox.set_wrap_width(3)
-            self._alignment_combobox.set_active(4)
+            self._alignment_combobox.set_active(alignment_labels.index(self.current_alignment))
 
 
 

--- a/asktext.py
+++ b/asktext.py
@@ -651,6 +651,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             self._alignment_combobox.set_model(liststore)
             self._alignment_combobox.set_wrap_width(3)
             self._alignment_combobox.set_active(alignment_labels.index(self.current_alignment))
+            self._alignment_combobox.set_tooltip_text("Set alignment anchor position")
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def main():
     success = green.format(success)
     failure = red.format(failure)
 
-    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "extension")
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)))
     destination = os.path.expanduser("~/.config/inkscape/extensions")
 
     num_copied_files = 0

--- a/textext.py
+++ b/textext.py
@@ -547,9 +547,7 @@ class TexText(inkex.Effect):
         :param node:
         :return: a, b, c, d, e, f   (the values of the transform matrix)
         """
-        transform = node.attrib['transform']
-        transform = transform.split('(', 1)[1].split(')')[0]
-        a, b, c, d, e, f = transform.split(',')
+        (a,c,e),(b,d,f) = st.parseTransform(node.attrib['transform'])
         return a, b, c, d, e, f
 
 

--- a/textext.py
+++ b/textext.py
@@ -158,6 +158,10 @@ def latest_message():
 
 
 class TexText(inkex.Effect):
+
+    DEFAULT_ALIGNMENT = "middle center"
+    ATTR_ALIGNMENT = '{%s}alignment' % TEXTEXT_NS
+
     def __init__(self):
         inkex.Effect.__init__(self)
 
@@ -212,6 +216,12 @@ class TexText(inkex.Effect):
         if old_node is not None and ('{%s}jacobian_sqrt' % TEXTEXT_NS in old_node.attrib.keys()):
             current_scale *= self.get_jacobian_sqrt(old_node)/float(old_node.attrib['{%s}jacobian_sqrt' % TEXTEXT_NS])
 
+        alignment = TexText.DEFAULT_ALIGNMENT
+
+        if  old_node is not None and TexText.ATTR_ALIGNMENT in old_node.attrib.keys():
+            alignment = old_node.attrib[TexText.ATTR_ALIGNMENT]
+
+
         # Ask for TeX code
         if self.options.text is None:
             global_scale_factor = self.options.scale_factor
@@ -222,7 +232,7 @@ class TexText(inkex.Effect):
             if not os.path.isfile(preamble_file):
                 preamble_file = ""
 
-            asker = AskerFactory().asker(text, preamble_file, global_scale_factor, current_scale)
+            asker = AskerFactory().asker(text, preamble_file, global_scale_factor, current_scale, current_alignment=alignment)
             try:
 
                 def callback(_text, _preamble, _scale, alignment="middle center"):
@@ -340,6 +350,7 @@ class TexText(inkex.Effect):
         new_node.attrib['{%s}text' % TEXTEXT_NS] = text.encode('string-escape')
         new_node.attrib['{%s}preamble' % TEXTEXT_NS] = preamble_file.encode('string-escape')
         new_node.attrib['{%s}scale' % TEXTEXT_NS] = str(user_scale_factor).encode('string-escape')
+        new_node.attrib['{%s}alignment' % TEXTEXT_NS] = str(alignment).encode('string-escape')
         try:
             new_node.attrib['{%s}inkscapeversion' % TEXTEXT_NS] = (
             self.document.getroot().attrib['{%s}version' % inkex.NSS["inkscape"]].split(' ')[0]).encode('string-escape')

--- a/textext.py
+++ b/textext.py
@@ -372,21 +372,13 @@ class TexText(inkex.Effect):
             except (KeyError, IndexError, TypeError, AttributeError):
                 pass
 
-            # calculate the size difference between the old and new node and translate the new node to keep it centered
-            old_scale = self.get_node_scale_factor(old_node)
+            relative_scale = user_scale_factor / float(old_node.attrib['{%s}scale' % TEXTEXT_NS])
+            scale_transform = st.parseTransform("scale(%d)" % relative_scale)
 
-            self.set_node_scale_factor(new_node, scale_factor)
+            old_transform = old_node.attrib['transform']
+            composition = st.parseTransform(old_transform, scale_transform)
 
-            x_old, y_old, w_old, h_old = self.get_node_frame(old_node, old_scale)
-            x_new, y_new, w_new, h_new = self.get_node_frame(new_node, scale_factor)
-
-            w_diff = w_old - w_new
-            h_diff = h_old - h_new
-
-            x_diff = x_old - x_new
-            y_diff = y_old - y_new
-
-            self.translate_node(new_node, w_diff / 2.0 + x_diff, -h_diff / 2.0 - y_diff)
+            new_node.attrib['transform'] = st.formatTransform(composition)
 
             self.replace_node(old_node, new_node)
 


### PR DESCRIPTION
This patch fixes issues with position and scale of object that was scaled manually in inkscape and then re-edited with textext (see #11, #13). 

Now scaling of textext object in inkscape is coupled with "scale factor" in plugin window. This behavior match behavior of native text objects in inkscape, so this is definitely right way to handle it. 

Here are several cycles of `create -> edit in inkscape -> edit content in textext -> scale to 1.0 in textext` with different transformations in inkscape. 

![g7354-9](https://user-images.githubusercontent.com/2975991/38366416-4d6cc912-38e8-11e8-8322-6abdc6fe805f.png)

Another improvement is addition of a control which allows to choose new positioning relative to old bounding box. This property is similar to "align" property of native text fields except it has two dimensions.

Here is an example of using this alignment property. The "original text" gets edited, scale and content are changed. Now user can affect the resulting positioning scheme. 

New GTK plugin window:
![g7354-10](https://user-images.githubusercontent.com/2975991/38367255-da9dada4-38ea-11e8-9b26-32cb55dddcdb.png)
Positioning after edition: 
![g7354-11](https://user-images.githubusercontent.com/2975991/38367258-dbf139dc-38ea-11e8-81aa-f98e7c0285aa.png)


I modified only GTK version of plugin window, but TK still works with limited functionality, namely 
- no alignment property, default value ("middle center") always used
- scale step is too big, so edited object may not exactly match in size original

Besides that its fully functional.

Note: this patch includes some cleanup, replacing hand-written procedures with analogues from inkscape.

Also this patch should not break documents which was build with older version of this plugin (I did some basic compatibility tests, but may be more extensive testing is required). 

Please, let me know if there are any issues with this PR. 
