### PR TITLE
Feature/pdf2svg support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@
 *.tar.gz
 tests/out.svg
 *.iss
+bezmisc.py
+cubicsuperpath.py
+inkex.py
+simplepath.py
+simplestyle.py
+simpletransform.py
 /PyGTK_for_Inkscape/0.92.2/build
 /PyGTK_for_Inkscape/0.92.2/download-*/
 /PyGTK_for_Inkscape/0.92.2/files/

--- a/textext.py
+++ b/textext.py
@@ -1228,52 +1228,10 @@ class Pdf2SvgSvgElement(SvgElement):
 
     def get_frame(self, mat=[[1,0,0],[0,1,0]]):
         """ Returns x_min, y_min, width and height of node"""
-
-        x_min = 1e6
-        x_max = -1e6
-        y_min = 1e6
-        y_max = -1e6
-
-        # Iterate over all path elements and determine their maximum and minumum x and y values. Note that the
-        # coordinates are translated by pdf2svg, so we have to account for this
-        for path_ele in self._node.xpath("//*[local-name() =\"path\"]"):
-            _, _, _, _, x_trans, y_trans = self.calc_transform_values(path_ele)
-            x_min_temp, x_max_temp, y_min_temp, y_max_temp = st.computeBBox([path_ele], mat)
-            x_min_temp += x_trans
-            x_max_temp += x_trans
-            y_min_temp += y_trans
-            y_max_temp += y_trans
-            if x_min_temp < x_min:
-                x_min = x_min_temp
-            if x_max_temp > x_max:
-                x_max = x_max_temp
-            if y_min_temp < y_min:
-                y_min = y_min_temp
-            if y_max_temp > y_max:
-                y_max = y_max_temp
-
-        # Do the same with the line elements
-        for line_ele in self._node.xpath("//*[local-name() =\"line\"]"):
-            _, _, _, _, x_trans, y_trans = self.calc_transform_values(line_ele)
-            x_min_temp, x_max_temp, y_min_temp, y_max_temp = st.computeBBox([line_ele], mat)
-            x_min_temp += x_trans
-            x_min_temp += x_trans
-            x_max_temp += x_trans
-            y_min_temp += y_trans
-            y_max_temp += y_trans
-            if x_min_temp < x_min:
-                x_min = x_min_temp
-            if x_max_temp > x_max:
-                x_max = x_max_temp
-            if y_min_temp < y_min:
-                y_min = y_min_temp
-            if y_max_temp > y_max:
-                y_max = y_max_temp
-
-        # Finally, we have to add the absolute translation of the frame
-        scale, _, _, _, x_trans, y_trans = self.get_transform_values()
-        scale = scale
-        return x_min * scale + x_trans, y_min * scale + y_trans, (x_max - x_min) * scale, (y_max - y_min) * scale
+        min_x, max_x, min_y, max_y = st.computeBBox([self._node], mat)
+        width = max_x - min_x
+        height = max_y - min_y
+        return min_x, min_y, width, height
 
     def get_transform_values(self):
         """
@@ -1281,18 +1239,9 @@ class Pdf2SvgSvgElement(SvgElement):
         depending on the transform applied
         See: https://www.w3.org/TR/SVG11/coords.html#TransformMatrixDefined
         """
-        return self.calc_transform_values(self._node)
-
-    @staticmethod
-    def calc_transform_values(node):
-        """
-        Returns the entries a, b, c, d, e, f of the node's transformation matrix
-        depending on the transform applied
-        See: https://www.w3.org/TR/SVG11/coords.html#TransformMatrixDefined
-        """
         a = b = c = d = e = f = 0
-        if 'transform' in node.attrib:
-            (a,c,e),(b,d,f) = st.parseTransform(node.attrib['transform'])
+        if 'transform' in self._node.attrib:
+            (a,c,e),(b,d,f) = st.parseTransform(self._node.attrib['transform'])
         return a, b, c, d, e, f
 
     def get_jacobian_sqrt(self):
@@ -1356,8 +1305,8 @@ class Pdf2SvgSvgElement(SvgElement):
 
 
 
-CONVERTERS = [PstoeditPlotSvg]
-#CONVERTERS = [Pdf2SvgPlotSvg]
+#CONVERTERS = [PstoeditPlotSvg]
+CONVERTERS = [Pdf2SvgPlotSvg]
 
 #------------------------------------------------------------------------------
 # Entry point

--- a/textext.py
+++ b/textext.py
@@ -1038,14 +1038,6 @@ class SvgElement(object):
         det = a * d - c * b
         return math.sqrt(math.fabs(det))
 
-    def get_scale_factor(self):
-        """
-        Extract the scale factor from the node's transform attribute
-        :return: scale factor
-        """
-        a, _, _, _, _, _ = self.get_transform_values()
-        return a
-
     def translate(self, x, y):
         """
         Translate the node

--- a/textext.py
+++ b/textext.py
@@ -1076,12 +1076,10 @@ class SvgElement(object):
         """ Sets the attribute attrib_name (str) to the value attrib_value (str) in the TexText namespace"""
         self._node.attrib['{%s}%s' % (TEXTEXT_NS, attrib_name)] = attrib_value.encode('string-escape')
 
-    @staticmethod
     @abc.abstractmethod
     def get_converter_name():
         """ Returns the converter used for creating the svg elemen """
 
-    @staticmethod
     @abc.abstractmethod
     def _calc_transform(scale_factor):
         """ Calculates the transformation matrix for a simple scaling"""
@@ -1358,8 +1356,8 @@ class Pdf2SvgSvgElement(SvgElement):
 
 
 
-#CONVERTERS = [PstoeditPlotSvg]
-CONVERTERS = [Pdf2SvgPlotSvg]
+CONVERTERS = [PstoeditPlotSvg]
+#CONVERTERS = [Pdf2SvgPlotSvg]
 
 #------------------------------------------------------------------------------
 # Entry point

--- a/textext.py
+++ b/textext.py
@@ -449,7 +449,7 @@ class TexText(inkex.Effect):
 
             # otherwise, check for TEXTEXT_NS in attrib
             if '{%s}text' % TEXTEXT_NS in node.attrib:
-                scale = None
+                scale = 1.0
                 if '{%s}scale' % TEXTEXT_NS in node.attrib:
                     scale_string = node.attrib.get('{%s}scale' % TEXTEXT_NS, '').decode('string-escape')
                     scale = float(scale_string)

--- a/textext.py
+++ b/textext.py
@@ -911,7 +911,7 @@ class Pdf2SvgPlotSvg(PdfConverterBase):
         """
         try:
             # Exec pdf2cvg infile.pdf outfile.svg
-            result = exec_command(['c:\\Progs\\pdf2svg\\pdf2svg', self.tmp('pdf'), self.tmp('svg')])
+            result = exec_command(['pdf2svg', self.tmp('pdf'), self.tmp('svg')])
         except RuntimeError as excpt:
             add_log_message("Command pdf2svg failed: %s" % (excpt))
             raise RuntimeError(latest_message())
@@ -981,7 +981,7 @@ class Pdf2SvgPlotSvg(PdfConverterBase):
         """
         Check if pdf2svg is available
         """
-        out = exec_command(['c:\\Progs\\pdf2svg\\pdf2svg', '--help'], ok_return_value=None)
+        out = exec_command(['pdf2svg', '--help'], ok_return_value=None)
 
 
 class SvgElement(object):

--- a/textext.py
+++ b/textext.py
@@ -938,7 +938,15 @@ class Pdf2SvgPlotSvg(PdfConverterBase):
             for node in svg_raw:
                 if node.tag != "{%s}defs" % SVG_NS:
                     new_group.append(node)
-            # return PsToEditSvgElement(copy.copy(tree.getroot().xpath('g')[0]))
+
+            # Ensure that strokes with color "none" have zero width to ensure proper colorization via Inkscape
+            for node in new_group.getiterator(tag="{%s}path" % SVG_NS):
+                if "style" in node.attrib:
+                    node_style_dict = ss.parseStyle(node.attrib["style"])
+                    if "stroke" in node_style_dict and node_style_dict["stroke"].lower() == "none":
+                        node_style_dict["stroke-width"] = "0"
+                        node.attrib["style"] = ss.formatStyle(node_style_dict)
+
             # return new_group
             return Pdf2SvgSvgElement(new_group)
 


### PR DESCRIPTION
This pull-request introduces the support of pdf2svg for converting the pdf output to svg. It resolves issue #2 and is a SUMO request. I know this is not what one really likes to review. However, major changes needed to be introduced into the code in order to use both, pstoedit as well as pdf2svg, as converters and defining an abstract interface for utilizing additional converters without tons of ifs and elses.

**Short summary:**
- New class `Pdf2SvgPlotSvg` for conversion pdf -> svg
- All methods in class `TexText` that are acting on the svg node moved to new class `SvgElement` encapsulating the svg node coming from `svg_to_group` and providing manipulation stuff
- `svg_to_group` of `pdf2svgPlotSvg`/ `PstoeditPlotSvg` returns an instance of `SvgElement` instead of xml node
- 2 subclasses of `SvgElement` providing pdf2svg and pstoedit specific stuff so we do not need to care about where the nodes coming from in the `TexText` class (especially useful when changing nodes via pdf2svg which have been originally created by pstoedit)
- Scaling feature from @sizmailov already included
- This pr also resolves issue #15 (compiling very old nodes, needed this patch for proper testing)

**Open:**
- Preserve colors defined in Inkscape
- Tk interface

Code works only if pdf2svg is found on the path. To use pstoedit comment/uncomment CONVERTERS in lines 1199/ 1200. (Will be in one list in final release).

**Long:**
Up to now, the workflow in `TexText` was as follows: The `PstoeditPlotSvg` class (derived from `LatexConverterBase`) returned an xml node via the method `svg_to_group`. The TexText class provided several methods for transforming, scaling and translating this node to ensure that it is placed correctly in the document.

Since svg code produced by pdf2svg fundamentally differs from svg code produced by pstoedit a new class `Pdf2svgPlotSvg` (derived from `PdfConverterBase`) has been introduced which does the conversion. Furthermore, since handling of the nodes must be partially specific to the used converter the `TexText` class would need to provide specific methods, too. This would blow the class up.

Hence, I introduced a new class called `SVGElement`, which encapsulates the xml node and provides all methods required for handling them. Converter specific methods are implemented in the subclasses `Pdf2SvgSvgElement` and `PstoEditSvgElement`. Then, the TextText class is only acting on instances of these classes and does not need to know where they come from. This is especially useful when modifying nodes using `pdf2svg`, which have been originally created by `pstoedit`.

My next step is to implement the possibility to keep color defined in Inkscape instead of using the LaTeX color. Furthermore, XeLaTex and LuaLaTex (issue #3) support will be added.
