### PR TITLE
Tk interface: Added TeX command selection and alignment control

### DIFF
--- a/asktext.py
+++ b/asktext.py
@@ -738,8 +738,8 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
 
             # We need buttons with custom labels and stock icons, so we make some
             reset_scale = self.current_scale_factor if self.current_scale_factor else self.global_scale_factor
-            items = [('tt-reset', 'Reset ({0:.1f})'.format(reset_scale), 0, 0, None),
-                     ('tt-global', 'Global ({0:.1f})'.format(self.global_scale_factor), 0, 0, None)]
+            items = [('tt-reset', 'Reset ({0:.3f})'.format(reset_scale), 0, 0, None),
+                     ('tt-global', 'From previous ({0:.3f})'.format(self.global_scale_factor), 0, 0, None)]
 
             # Forcibly show icons
             settings = gtk.settings_get_default()
@@ -759,12 +759,12 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
 
             scale_reset_button = gtk.Button(stock='tt-reset')
             scale_reset_button.set_tooltip_text(
-                "Set scale factor to the value this node has been created with ({0:.1f})".format(reset_scale))
+                "Set scale factor to the value this node has been created with ({0:.3f})".format(reset_scale))
             scale_reset_button.connect('clicked', self.reset_scale_factor)
 
             scale_global_button = gtk.Button(stock='tt-global')
             scale_global_button.set_tooltip_text(
-                "Set scale factor to the value of the previously edited node in Inkscape ({0:.1f})".format(
+                "Set scale factor to the value of the previously edited node in Inkscape ({0:.3f})".format(
                     self.global_scale_factor))
             scale_global_button.connect('clicked', self.use_global_scale_factor)
 

--- a/asktext.py
+++ b/asktext.py
@@ -215,7 +215,6 @@ if TOOLKIT == TK:
                                             current_alignment, current_texcmd)
             self._frame = None
             self._scale = None
-            self._alignment_tk_str = None
 
         def ask(self, callback, preview_callback=None):
             self.callback = callback
@@ -233,6 +232,18 @@ if TOOLKIT == TK:
             self._preamble = Tk.Entry(box)
             self._preamble.pack(expand=True, fill="x", pady=5, padx=5)
             self._preamble.insert(Tk.END, self.preamble_file)
+            box.pack(fill="x", pady=5, expand=True)
+
+            # Frame box for tex command
+            tex_command_tk_str = Tk.StringVar()
+            tex_command_tk_str.set(self.current_texcmd)
+
+            box = Tk.Frame(self._frame, relief="groove", borderwidth=2)
+            label = Tk.Label(box, text="TeX command:")
+            label.pack(pady=2, padx=5, anchor="w")
+            for tex_command in self.TEX_COMMANDS:
+                Tk.Radiobutton(box, text=tex_command, variable=tex_command_tk_str,
+                               value=tex_command).pack(side="left", expand=False, anchor="w")
             box.pack(fill="x", pady=5, expand=True)
 
             # Frame box for scale factor and reset buttons
@@ -266,15 +277,15 @@ edited node in Inkscape."""
             label = Tk.Label(box, text="Alignment to existing node:")
             label.pack(pady=2, padx=5, anchor="w")
 
-            self._alignment_tk_str = Tk.StringVar() # Does not work in ctor, and Tk.Tk() in front opens 2nd window
-            self._alignment_tk_str.set(self.current_alignment) # Variable holding the radio button selection
+            alignment_tk_str = Tk.StringVar() # Does not work in ctor, and Tk.Tk() in front opens 2nd window
+            alignment_tk_str.set(self.current_alignment) # Variable holding the radio button selection
 
             alignment_index_list = [0, 3, 6, 1, 4, 7, 2, 5, 8] # To pick labels columnwise: xxx-left, xxx-center, ...
             vbox = None
             for i, ind in enumerate(alignment_index_list):
                 if i % 3 == 0:
                     vbox = Tk.Frame(box)
-                Tk.Radiobutton(vbox, text=self.ALIGNMENT_LABELS[ind], variable=self._alignment_tk_str,
+                Tk.Radiobutton(vbox, text=self.ALIGNMENT_LABELS[ind], variable=alignment_tk_str,
                                value=self.ALIGNMENT_LABELS[ind]).pack(expand=True, anchor="w")
                 if (i + 1) % 3 == 0:
                     vbox.pack(side="left", fill="x", expand=True)
@@ -308,7 +319,8 @@ edited node in Inkscape."""
 
             root.mainloop()
 
-            self.callback(self.text, self.preamble_file, self.global_scale_factor, self._alignment_tk_str.get())
+            self.callback(self.text, self.preamble_file, self.global_scale_factor, alignment_tk_str.get(),
+                          tex_command_tk_str.get())
             return self.text, self.preamble_file, self.global_scale_factor
 
         def cb_ok(self, widget=None, data=None):

--- a/textext.py
+++ b/textext.py
@@ -1214,8 +1214,8 @@ class Pdf2SvgSvgElement(SvgElement):
         return transform_as_list
 
 
-CONVERTERS = [PstoeditPlotSvg]
-#CONVERTERS = [Pdf2SvgPlotSvg]
+#CONVERTERS = [PstoeditPlotSvg]
+CONVERTERS = [Pdf2SvgPlotSvg]
 
 #------------------------------------------------------------------------------
 # Entry point

--- a/textext.py
+++ b/textext.py
@@ -1214,8 +1214,8 @@ class Pdf2SvgSvgElement(SvgElement):
         return transform_as_list
 
 
-#CONVERTERS = [PstoeditPlotSvg]
-CONVERTERS = [Pdf2SvgPlotSvg]
+CONVERTERS = [PstoeditPlotSvg]
+#CONVERTERS = [Pdf2SvgPlotSvg]
 
 #------------------------------------------------------------------------------
 # Entry point


### PR DESCRIPTION
This pull request offers an update of the Tk interface so it matches the functionality of the GTK interface. I know it is not a candidate for a design award. But it does what it is meant for.

![grafik](https://user-images.githubusercontent.com/11866252/39971995-87277562-5706-11e8-92d2-2e501bac3d92.png)

Since combo boxes are not available in the Tk version shipped with Inkscape on Windows / Python 2.7 I used radio buttons.

Furthermore, I renamed the label of the `global` scale factor button to `From previous`according to the discussion in issue #16.

The scale buttons do show the full resolution of the factor now. (Do we really need 3 decimals?)

Open: Disable alignment controls when creating a new node (Tk and GTK).