### PR TITLE
Keep Inkscape / TeX colors

### DIFF
--- a/default_packages.tex
+++ b/default_packages.tex
@@ -1,1 +1,2 @@
 \usepackage{amsmath,amsthm,amssymb,amsfonts}
+\usepackage{color}

--- a/textext.py
+++ b/textext.py
@@ -956,7 +956,15 @@ class Pdf2SvgPlotSvg(PdfConverterBase):
             for node in svg_raw:
                 if node.tag != "{%s}defs" % SVG_NS:
                     new_group.append(node)
-            # return PsToEditSvgElement(copy.copy(tree.getroot().xpath('g')[0]))
+
+            # Ensure that strokes with color "none" have zero width to ensure proper colorization via Inkscape
+            for node in new_group.getiterator(tag="{%s}path" % SVG_NS):
+                if "style" in node.attrib:
+                    node_style_dict = ss.parseStyle(node.attrib["style"])
+                    if "stroke" in node_style_dict and node_style_dict["stroke"].lower() == "none":
+                        node_style_dict["stroke-width"] = "0"
+                        node.attrib["style"] = ss.formatStyle(node_style_dict)
+
             # return new_group
             return Pdf2SvgSvgElement(new_group)
 

--- a/textext.py
+++ b/textext.py
@@ -392,7 +392,7 @@ class TexText(inkex.Effect):
             relative_scale = user_scale_factor / original_scale
             new_svg_ele.align_to_node(old_svg_ele, alignment, relative_scale)
 
-            # If no non-black color has been explicitely set by TeX we copy the color information from the old node
+            # If no non-black color has been explicitily set by TeX we copy the color information from the old node
             # so that coloring done in Inkscape is preserved.
             if not new_svg_ele.is_colorized():
                 new_svg_ele.import_group_color_style(old_svg_ele)
@@ -1238,10 +1238,7 @@ class PsToEditSvgElement(SvgElement):
         """ Returns true if at least one element of the node contains a non-black fill or stroke color """
         # pstoedit stores color information as attributes, not as css styles, so checking for attributes should
         # be enough. But to be on the save side...
-        has_color = self.has_colorized_attribute(self._node)
-        if not has_color:
-            has_color = self.has_colorized_style(self._node)
-        return has_color
+        return self.has_colorized_attribute(self._node) or self.has_colorized_style(self._node)
 
     def _check_and_fix_transform(self, ref_node, transform_as_list):
         """ Fixes vertical flipping of nodes which have been originally created via pdf2svg"""
@@ -1269,10 +1266,7 @@ class Pdf2SvgSvgElement(SvgElement):
         """ Returns true if at least one element of the node contains a non-black fill or stroke color """
         # pdf2svg consequently uses the style css properties for colorization, so checking for style should
         # be enough. But to be on the save side...
-        has_color = self.has_colorized_style(self._node)
-        if not has_color:
-            has_color = self.has_colorized_attribute(self._node)
-        return has_color
+        return self.has_colorized_style(self._node) or self.has_colorized_attribute(self._node)
 
     def _check_and_fix_transform(self, ref_node, transform_as_list):
         """ Fixes vertical flipping of nodes which have been originally created via pstoedit """


### PR DESCRIPTION
This pull request relates to issue #21.

If svg code coming from the converter contains non-black styles -> TeX colorization is kept

If everything is black coming from the converter -> Inkscape top level group color/ opacity is preserved

See commit messages for more details.

Note that pstoedit colorizes its items using "fill" etc. while pdf2svg uses css styles (as Inkscape). Neverthelss I check for both ways in both converters `is_colorized` methods. Maybe too paranoid?

Tested both converters in Inkscape 0.92. 