### PR TITLE
Check requirements at install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -408,7 +408,7 @@ def check_requirements():
         except (OSError, subprocess.CalledProcessError):
             return RequirementCheckResult(False, ["ghostscript=%s is not found" % version])
 
-        first_stdout_line = stdout.split("\n")[0]
+        first_stdout_line = stdout.decode("utf-8").split("\n")[0]
         m = re.search(r"(\d+.\d+)", first_stdout_line)
         if m:
             found_version = m.group(1)
@@ -426,7 +426,7 @@ def check_requirements():
         except (OSError, subprocess.CalledProcessError):
             return RequirementCheckResult(False, ["pstoedit=%s is not found" % version])
 
-        first_stderr_line = stderr.split("\n")[0]
+        first_stderr_line = stderr.decode("utf-8").split("\n")[0]
         m = re.search(r"version (\d+.\d+)", first_stderr_line)
         if m:
             found_version = m.group(1)

--- a/setup.py
+++ b/setup.py
@@ -527,6 +527,13 @@ if __name__ == "__main__":
         help="Bypass minimal requirements check"
     )
 
+    parser.add_argument(
+        "--skip-extension-install",
+        default=False,
+        action='store_true',
+        help="Don't install extension"
+    )
+
     args = parser.parse_args()
 
     if not args.skip_requirements_check:
@@ -543,15 +550,16 @@ if __name__ == "__main__":
             logger.info("To bypass requirement check pass `--skip-requirements-check` to setup.py")
             exit(65)
 
-    try:
-        copy_extension_files(
-            src="extension/*",
-            dst=args.inkscape_extensions_path,
-            if_already_exists=args.if_already_exists
-        )
-    except CopyFileAlreadyExistsError:
-        logger.info("Hint: add `--overwrite-if-exist` option to overwrite existing files and directories")
-        logger.info("Hint: add `--skip-if-exist` option to retain existing files and directories")
-        exit(66)
+    if not args.skip_extension_install:
+        try:
+            copy_extension_files(
+                src="extension/*",
+                dst=args.inkscape_extensions_path,
+                if_already_exists=args.if_already_exists
+            )
+        except CopyFileAlreadyExistsError:
+            logger.info("Hint: add `--overwrite-if-exist` option to overwrite existing files and directories")
+            logger.info("Hint: add `--skip-if-exist` option to retain existing files and directories")
+            exit(66)
 
     exit(0)

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,73 @@ import glob
 import shutil
 
 
+def colorize_logging():
+    RESET = "\033[0m"
+    FG_DEFAULT = "\033[39m"
+    FG_BLACK = "\033[30m"
+    FG_RED = "\033[31m"
+    FG_GREEN = "\033[32m"
+    FG_YELLOW = "\033[33m"
+    FG_BLUE = "\033[34m"
+    FG_MAGENTA = "\033[35m"
+    FG_CYAN = "\033[36m"
+    FG_LIGHT_GRAY = "\033[37m"
+    FG_DARK_GRAY = "\033[90m"
+    FG_LIGHT_RED = "\033[91m"
+    FG_LIGHT_GREEN = "\033[92m"
+    FG_LIGHT_YELLOW = "\033[93m"
+    FG_LIGHT_BLUE = "\033[94m"
+    FG_LIGHT_MAGENTA = "\033[95m"
+    FG_LIGHT_CYAN = "\033[96m"
+    FG_WHITE = "\033[97m"
+
+    BG_DEFAULT = "\033[49m"
+    BG_BLACK = "\033[40m"
+    BG_RED = "\033[41m"
+    BG_GREEN = "\033[42m"
+    BG_YELLOW = "\033[43m"
+    BG_BLUE = "\033[44m"
+    BG_MAGENTA = "\033[45m"
+    BG_CYAN = "\033[46m"
+    BG_LIGHT_GRAY = "\033[47m"
+    BG_DARK_GRAY = "\033[100m"
+    BG_LIGHT_RED = "\033[101m"
+    BG_LIGHT_GREEN = "\033[102m"
+    BG_LIGHT_YELLOW = "\033[103m"
+    BG_LIGHT_BLUE = "\033[104m"
+    BG_LIGHT_MAGENTA = "\033[105m"
+    BG_LIGHT_CYAN = "\033[106m"
+    BG_WHITE = "\033[107m"
+
+
+    levels = [
+              logging.DEBUG,
+              logging.INFO,
+              logging.WARNING,
+              logging.ERROR,
+              logging.ERROR+1, # SUCCESS
+              logging.CRITICAL
+    ]
+    names = [
+        "DEBUG   ",
+        "INFO    ",
+        "WARNING ",
+        "ERROR   ",
+        "SUCCESS ",
+        "CRITICAL"
+    ]
+    colors = [
+        RESET,
+        BG_DEFAULT + FG_LIGHT_BLUE,
+        BG_DEFAULT + FG_YELLOW,
+        BG_DEFAULT + FG_RED,
+        BG_DEFAULT + FG_GREEN,
+        BG_RED + FG_WHITE,
+    ]
+    for level, name, color in zip(levels, names, colors):
+        logging.addLevelName(level, color + name + RESET)
+
+
 class CopyFileOverDirectoryError(RuntimeError):
     pass
 
@@ -23,7 +90,7 @@ def copy_extension_files(src, dst, if_already_exists="raise"):
     """
     if os.path.exists(dst):
         if not os.path.isdir(dst):
-            logger.error("Can't copy files to `%s`: it's not a directory")
+            logger.critical("Can't copy files to `%s`: it's not a directory")
             raise CopyFileOverDirectoryError("Can't copy files to `%s`: it's not a directory")
     else:
         logger.info("Creating directory `%s`"%dst)
@@ -34,7 +101,7 @@ def copy_extension_files(src, dst, if_already_exists="raise"):
         destination = os.path.join(dst,basename)
         if os.path.exists(destination):
             if if_already_exists=="raise":
-                logger.error("Can't copy `%s`: `%s` already exists"%(file,destination))
+                logger.critical("Can't copy `%s`: `%s` already exists"%(file,destination))
                 raise CopyFileAlreadyExistsError("Can't copy `%s`: `%s` already exists"%(file,destination))
             elif if_already_exists=="skip":
                 logger.info("Skipping `%s`"%file)
@@ -60,6 +127,135 @@ def copy_extension_files(src, dst, if_already_exists="raise"):
                                    if_already_exists=if_already_exists)
 
 
+
+class RequirementCheckResult(object):
+    def __init__(self, value, messages, nested=None):
+        self.value = value
+        self.messages = messages
+        self.nested = nested if nested is not None else []
+
+    def print_to_logger(self, offset=0):
+        if self.value:
+            lvl = logging.ERROR + 1  # success
+        else:
+            lvl = logging.ERROR
+
+        if self.nested:
+            nest_symbol = "+"
+        else:
+            nest_symbol = ""
+
+        for msg in self.messages:
+            line = ""
+            if offset > 0:
+                if offset > 1:
+                    line += " " * (offset - 1)
+                line += (offset - 1) * 2 * " " + "|" + "--"
+
+            line += nest_symbol
+            line += " " + msg + "[%d]" % offset
+
+            logger.log(lvl, line)
+
+            if self.nested:
+                nest_symbol = "|"
+            else:
+                nest_symbol = ""
+
+        for nst in self.nested:
+            nst.print_to_logger(offset + 1)
+
+    def flatten(self):
+        if len(self.nested) == 0:
+            return self
+
+        if self.nested[0].messages == ["OR"] and self.messages == ["OR"]:
+            return RequirementCheckResult(
+                    self.value,
+                    ["OR"],
+                    self.nested[0].nested + self.nested[1:]
+                ).flatten()
+
+        if self.nested[0].messages == ["AND"] and self.messages == ["AND"]:
+            return RequirementCheckResult(
+                    self.value,
+                    ["AND"],
+                    self.nested[0].nested + self.nested[1:]
+                ).flatten()
+
+        return self
+
+
+class Requirement(object):
+    def __init__(self, criteria):
+        # type: (Callable[None,RequirementCheckResult]) -> None
+        self.criteria = criteria  # type: Callable[None, RequirementCheckResult]
+
+    def check(self):
+        # type: () -> RequirementCheckResult
+        return self.criteria()
+
+    def __and__(self, rhs):
+        # type: (Requirement) -> Requirement
+        def and_impl():
+            L = self.check()
+            R = rhs.check()
+            return RequirementCheckResult(L.value and R.value,
+                                          ["AND"],
+                                          [L, R]
+                                          )
+
+        return Requirement(and_impl)
+
+    def __or__(self, rhs):
+        # type: (Requirement) -> Requirement
+        def or_impl():
+            L = self.check()
+            R = rhs.check()
+            return RequirementCheckResult(L.value or R.value,
+                                          ["OR"],
+                                          [L, R]
+                                          )
+        return Requirement(or_impl)
+
+    def __neg__(self, other):
+        # type: (Requirement) -> Requirement
+        def neg_impl():
+            lhs_value, lhs_messages = self.check()
+            return RequirementCheckResult(not lhs_value,
+                                          ["NOT"],
+                                          lhs_messages
+                                          )
+        return Requirement(neg_impl)
+
+
+def check_requirements():
+    def find_in_PATH(executable):
+        messages = []
+        for path in os.environ["PATH"].split(":"):
+            full_path_guess = os.path.join(path, executable)
+            logger.debug("Looking for `%s` in `%s`" % (executable, path))
+            if os.path.isfile(full_path_guess):
+                logger.debug("Found `%s` at `%s`"%(executable,path))
+                messages.append("Found `%s` at `%s`"%(executable,path))
+        if len(messages)>0:
+            return RequirementCheckResult(True, messages)
+        messages.append("`%s` is not found PATH" % (executable))
+        return RequirementCheckResult(False, messages)
+
+    r = (
+        Requirement(lambda : find_in_PATH("pdflatex"))|
+        Requirement(lambda : find_in_PATH("laulatex"))|
+        Requirement(lambda : find_in_PATH("xelatex"))
+    )
+
+    check_result = r.check()
+
+    check_result = check_result.flatten()
+
+    check_result.print_to_logger()
+
+colorize_logging()
 logger = logging.getLogger('TexText')
 logger.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()
@@ -70,7 +266,6 @@ logger.addHandler(ch)
 
     
 if __name__ == "__main__":
-
 
     parser = argparse.ArgumentParser(description='Install TexText')
     
@@ -99,6 +294,8 @@ if __name__ == "__main__":
         )
 
     args = parser.parse_args()
+
+    check_requirements()
 
     try:
         copy_extension_files(

--- a/setup.py
+++ b/setup.py
@@ -442,7 +442,7 @@ def check_requirements():
             &
             (
                     Requirement(find_executable, "pdflatex") |
-                    Requirement(find_executable, "laulatex") |
+                    Requirement(find_executable, "lualatex") |
                     Requirement(find_executable, "xelatex")
             ).overwrite_check_message("Detect *latex")
             &

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ class RequirementCheckResult(object):
                 line += (offset - 1) * 2 * " " + "|" + "--"
 
             line += nest_symbol
-            line += " " + msg + "[%d]" % offset
+            line += " " + msg
 
             logger.log(lvl, line)
 

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,7 @@ class TrinaryLogicValue(object):
         return TrinaryLogicValue(not self.value)
 
     def __eq__(self, rhs):
-        if isinstance(rhs,TrinaryLogicValue):
+        if isinstance(rhs, TrinaryLogicValue):
             return self.value is None and rhs.value is None or self.value == rhs.value
         return self.value is None and rhs is None or self.value == rhs
 
@@ -167,8 +167,7 @@ class TrinaryLogicValue(object):
         return not self.__eq__(rhs)
 
     def __str__(self):
-        return "TrinaryLogicValue(%s)"%self.value
-
+        return "TrinaryLogicValue(%s)" % self.value
 
 
 class RequirementCheckResult(object):
@@ -194,13 +193,12 @@ class RequirementCheckResult(object):
             if offset == 0:
                 lvl = logging.CRITICAL
         else:
-            lvl = logging.ERROR + 2 # unknown
+            lvl = logging.ERROR + 2  # unknown
 
         if self.nested:
             nest_symbol = "-+"
         else:
             nest_symbol = ""
-
 
         tail = "/-----"
 
@@ -230,19 +228,19 @@ class RequirementCheckResult(object):
             nst.print_to_logger(offset + 1, self)
 
     def _cleanup_flatten_messages(self, messages):
-        new_msgs=[]
+        new_msgs = []
         prev_msg = None
 
         # remove consequent repeats
         for m in messages:
-            if m!=prev_msg:
+            if m != prev_msg:
                 new_msgs.append(m)
             prev_msg = m
 
         # remove "OR"/"AND" messages if there are anything else
-        or_and = {"OR","AND"}
-        if len(set(new_msgs) - or_and )>0:
-            return [ m for m in new_msgs if m not in or_and]
+        or_and = {"OR", "AND"}
+        if len(set(new_msgs) - or_and) > 0:
+            return [m for m in new_msgs if m not in or_and]
 
         return new_msgs
 
@@ -270,7 +268,7 @@ class RequirementCheckResult(object):
         if self.nested[-1].is_or_node and self.is_or_node:
             return RequirementCheckResult(
                 self.value,
-                self.messages+self.nested[-1].messages,
+                self.messages + self.nested[-1].messages,
                 self.nested[:-1] + self.nested[-1].nested
             )
 
@@ -286,9 +284,9 @@ class RequirementCheckResult(object):
 
 class Requirement(object):
     def __init__(self, criteria, *args, **kwargs):
-        self.criteria = lambda: criteria(*args,**kwargs)
-        self._prepended_messages = {"ANY":[],"SUCCESS":[],"ERROR":[],"UNKNOWN":[]}
-        self._appended_messages = {"ANY":[],"SUCCESS":[],"ERROR":[],"UNKNOWN":[]}
+        self.criteria = lambda: criteria(*args, **kwargs)
+        self._prepended_messages = {"ANY": [], "SUCCESS": [], "ERROR": [], "UNKNOWN": []}
+        self._appended_messages = {"ANY": [], "SUCCESS": [], "ERROR": [], "UNKNOWN": []}
         self._overwrite_messages = None
 
     def check(self):
@@ -316,20 +314,20 @@ class Requirement(object):
 
     def prepend_message(self, result_type, message):
         assert result_type in self._prepended_messages.keys()
-        if not isinstance(message,list):
+        if not isinstance(message, list):
             message = [message]
         self._prepended_messages[result_type].extend(message)
         return self
 
     def overwrite_check_message(self, message):
-        if not isinstance(message,list):
+        if not isinstance(message, list):
             message = [message]
         self._overwrite_messages = message
         return self
 
     def append_message(self, result_type, message):
         assert result_type in self._appended_messages.keys()
-        if not isinstance(message,list):
+        if not isinstance(message, list):
             message = [message]
         self._appended_messages[result_type].extend(message)
         return self
@@ -438,7 +436,7 @@ def check_requirements():
         return RequirementCheckResult(None, ["Can't determinate pstoedit version"])
 
     textext_requirements = (
-            Requirement(find_executable, "python2.7").prepend_message("ANY",'Detect `pytohn2.7`')
+            Requirement(find_executable, "python2.7").prepend_message("ANY", 'Detect `pytohn2.7`')
             &
             (
                     Requirement(find_executable, "pdflatex") |
@@ -458,20 +456,20 @@ def check_requirements():
             &
             (
                     (
-                    ~(
-                            Requirement(find_pstoedit, "3.70") &
-                            Requirement(find_ghostscript, "9.22")
-                    ).overwrite_check_message("Detect incompatible versions of psedit+ghostscript")
-                    &
-                    (
-                            Requirement(find_executable, "pstoedit") &
-                            Requirement(find_executable, "ghostscript")
-                    )
+                            ~(
+                                    Requirement(find_pstoedit, "3.70") &
+                                    Requirement(find_ghostscript, "9.22")
+                            ).overwrite_check_message("Detect incompatible versions of psedit+ghostscript")
+                            &
+                            (
+                                    Requirement(find_executable, "pstoedit") &
+                                    Requirement(find_executable, "ghostscript")
+                            )
                     ).overwrite_check_message("Detect compatible psedit+ghostscript versions")
                     |
                     (
                         Requirement(find_executable, "pdf2svg")
-                    ).prepend_message("ANY","Detect pdf2svg:")
+                    ).prepend_message("ANY", "Detect pdf2svg:")
             ).overwrite_check_message("Detect pdf->svg conversion utility")
     ).overwrite_check_message("TexText requirements")
 
@@ -541,7 +539,7 @@ if __name__ == "__main__":
         if check_result == None:
             logger.info("Automatic requirements check is incomplete")
             logger.info("Please check requirements list manually and run:")
-            logger.info(" ".join(sys.argv+["--skip-requirements-check"]))
+            logger.info(" ".join(sys.argv + ["--skip-requirements-check"]))
             exit(64)
 
         if check_result == False:

--- a/test_installation_script.py
+++ b/test_installation_script.py
@@ -106,3 +106,12 @@ test_configuration([
     ("pstoedit",),
     ("ghostscript",)
 ], REQUIREMENT_CHECK_UNKNOWN)
+
+test_configuration([
+    ("python2.7",),
+    ("pdflatex",),
+    ("convert",),
+    ("pstoedit",),
+    ("ghostscript",),
+    ("pdf2svg",)
+], REQUIREMENT_CHECK_SUCCESS)

--- a/test_installation_script.py
+++ b/test_installation_script.py
@@ -1,0 +1,108 @@
+"""
+
+This script creates fake executables (pdflatex, python2.7, etc...)
+to test requirements check in setup.py
+
+All fake executables are created in temporary directory and safely deleted at the end.
+
+setup.py is running with PATH set to temporary directory, so actual environment
+does not affect this test
+
+"""
+import os
+import shutil
+import sys
+import subprocess
+import tempfile
+
+
+class TempDirectory(object):
+    def __init__(self):
+        self.name = None
+
+    def __enter__(self):
+        self.name = tempfile.mkdtemp()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.name is not None:
+            shutil.rmtree(self.name)
+
+
+class FakeExecutablesMaker(object):
+    def __init__(self, dirname):
+        assert os.path.isdir(dirname)
+        self.dirname = dirname
+
+    def __call__(self, name, output="", channel='stdout'):
+        assert channel in ["stdout", "stderr"]
+        command_name = os.path.join(self.dirname, name)
+        with open(command_name, "w") as fout:
+            fout.write("#!%s\n" % sys.executable)
+            fout.write("from __future__ import print_function\n")
+            fout.write("import sys\n")
+            fout.write("print(%s, file=sys.%s)" % (repr(output), channel))
+        os.chmod(command_name, 0o755)
+
+
+def test_configuration(fake_commands, expected_exit_code):
+    with TempDirectory() as f:
+        env = dict(os.environ, PATH=f.name)
+        make_fake_executable = FakeExecutablesMaker(f.name)
+        for args in fake_commands:
+            make_fake_executable(*args)
+
+        ret_code = subprocess.call([sys.executable,
+                                    'setup.py',
+                                    "--skip-extension-install"],
+                                   env=env
+                                   )
+        assert ret_code == expected_exit_code, '%d != %d' % (ret_code, expected_exit_code)
+
+
+REQUIREMENT_CHECK_SUCCESS = 0
+REQUIREMENT_CHECK_UNKNOWN = 64
+REQUIREMENT_CHECK_ERROR = 65
+
+good_configurations = []
+for pdf2png in [("convert",), ("magick",)]:
+    for pdf2svg in [[("pstoedit", "version 1.1", "stderr"),
+                     ("ghostscript", "9.25")
+                     ],
+                    [("pdf2svg",)]
+                    ]:
+        for latex in [("pdflatex",), ("lualatex",), ("xelatex",)]:
+            good_configurations.append([
+                                           ("python2.7",),
+                                           pdf2png,
+                                           latex
+                                       ] + pdf2svg)
+
+for good_configuration in good_configurations:
+    test_configuration(good_configuration, REQUIREMENT_CHECK_SUCCESS)
+
+for good_configuration in good_configurations:
+    for i in range(len(good_configuration)):
+        # good configuration without one element is bad
+        bad_configuration = good_configuration[:i] + good_configuration[i + 1:]
+        test_configuration(bad_configuration, REQUIREMENT_CHECK_ERROR)
+
+test_configuration([
+    ("python2.7",)
+], REQUIREMENT_CHECK_ERROR)
+
+test_configuration([
+    ("python2.7",),
+    ("pdflatex",),
+    ("convert",),
+    ("pstoedit", "version 3.70", "stderr"),
+    ("ghostscript", "9.22")
+], REQUIREMENT_CHECK_ERROR)
+
+test_configuration([
+    ("python2.7",),
+    ("pdflatex",),
+    ("convert",),
+    ("pstoedit",),
+    ("ghostscript",)
+], REQUIREMENT_CHECK_UNKNOWN)


### PR DESCRIPTION
This PR is based on #53, so #53 should be merged first. 

This adds requirement checks to setup.py

Requirements are expressed in a form of expressions, so it's very easy to extend/modify without 
breaking the logic:
https://github.com/sizmailov/textext/blob/check_requirements_at_install/setup.py#L445-L481

Requirements has feature to extend printed messages depending on it's check result. It might be used to guide user through issues, provide links to docs, etc. 

The result of check is printed as a tree, so it's easy to tell what went wrong:

![image](https://user-images.githubusercontent.com/2975991/47599735-c3fcbe00-d9bc-11e8-8a38-d34cf70c019b.png)

`test_installation_script.py` mocks required executables  to test `setup.py` in various situations.

For example this test case simulates version parse errors of ghostscript and pstoedit. Check is succeed because of available pdf2svg:
![image](https://user-images.githubusercontent.com/2975991/47599721-8bf57b00-d9bc-11e8-9e6d-3a8d582ff3f5.png)


close #54 