### PR TITLE
Improve error handling + setup.py update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   only:
   - master
   - dev
+  - develop
   - travis_ci
   - rework_error_handling
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,18 +24,6 @@ matrix:
           - texlive-latex-base
 
     - os: linux
-      dist: precise
-      addons:
-        apt:
-          packages:
-          - pstoedit
-          - pdf2svg
-          - inkscape
-          - python-gtk2-dev
-          - imagemagick
-          - texlive-latex-base
-
-    - os: linux
       dist: xenial
       addons:
         apt:

--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -51,16 +51,16 @@ import subprocess
 
 DEBUG = False
 
-MAC = "Mac OS"
+MAC = "Darwin"
 WINDOWS = "Windows"
 PLATFORM = platform.system()
 
-# if PLATFORM == MAC:
-#     sys.path.append('/Applications/Inkscape.app/Contents/Resources/extensions')
-#     sys.path.append('/usr/local/lib/python2.7/site-packages')
-#     sys.path.append('/usr/local/lib/python2.7/site-packages/gtk-2.0')
+if PLATFORM == MAC:
+    sys.path.append('/Applications/Inkscape.app/Contents/Resources/extensions')
+    sys.path.append('/usr/local/lib/python2.7/site-packages')
+    sys.path.append('/usr/local/lib/python2.7/site-packages/gtk-2.0')
 
-#sys.path.append(os.path.dirname(__file__))
+sys.path.append(os.path.dirname(__file__))
 
 import inkex
 import simplestyle as ss

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -33,6 +33,7 @@ TK = "TK"
 TOOLKIT = None
 
 import os
+import warnings
 
 # unfortunately, with Inkscape being 32bit on OSX, I couldn't get GTKSourceView to work, yet
 
@@ -921,17 +922,19 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             return window
 
         def ask(self, callback, preview_callback=None):
-            self.callback = callback
-            self._preview_callback = preview_callback
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", module="asktext")
+                self.callback = callback
+                self._preview_callback = preview_callback
 
-            # create first window
-            window = self.create_window()
-            window.set_default_size(500, 500)
-            window.show()
+                # create first window
+                window = self.create_window()
+                window.set_default_size(500, 500)
+                window.show()
 
-            self._window = window
-            self._window.set_focus(self._source_view)
+                self._window = window
+                self._window.set_focus(self._source_view)
 
-            # main loop
-            gtk.main()
-            return self.text, self.preamble_file, self.global_scale_factor
+                # main loop
+                gtk.main()
+                return self.text, self.preamble_file, self.global_scale_factor

--- a/setup.py
+++ b/setup.py
@@ -674,6 +674,19 @@ if __name__ == "__main__":
         help="Enables/disable console colors"
     )
 
+    files_to_keep = {  # old_name : new_name
+        "default_packages.tex": "textext/default_packages.tex",  # old layout
+        "textext/default_packages.tex": "textext/default_packages.tex"  # new layout
+    }
+
+    args = parser.parse_args()
+    args.inkscape_extensions_path = os.path.expanduser(args.inkscape_extensions_path)
+
+    if args.color == "always":
+        LoggingColors.enable_colors = True
+    elif args.color == "never":
+        LoggingColors.enable_colors = False
+
     colorize_logging()
     logger = logging.getLogger('TexText')
     logger.setLevel(logging.DEBUG)
@@ -682,14 +695,6 @@ if __name__ == "__main__":
     formatter = logging.Formatter('[%(name)s][%(levelname)6s]: %(message)s')
     ch.setFormatter(formatter)
     logger.addHandler(ch)
-
-    files_to_keep = {  # old_name : new_name
-        "default_packages.tex": "textext/default_packages.tex",  # old layout
-        "textext/default_packages.tex": "textext/default_packages.tex"  # new layout
-    }
-
-    args = parser.parse_args()
-    args.inkscape_extensions_path = os.path.expanduser(args.inkscape_extensions_path)
 
     if args.keep_previous_installation_files is None:
         found_files_to_keep = {}
@@ -718,11 +723,6 @@ if __name__ == "__main__":
 
     if not args.keep_previous_installation_files:
         files_to_keep = {}
-
-    if args.color == "always":
-        LoggingColors.enable_colors = True
-    elif args.color == "never":
-        LoggingColors.enable_colors = False
 
     if not args.skip_requirements_check:
         check_result = check_requirements()

--- a/setup.py
+++ b/setup.py
@@ -696,34 +696,6 @@ if __name__ == "__main__":
     ch.setFormatter(formatter)
     logger.addHandler(ch)
 
-    if args.keep_previous_installation_files is None:
-        found_files_to_keep = {}
-        for old_filename, new_filename in files_to_keep.iteritems():
-            if not os.path.isfile(os.path.join(args.inkscape_extensions_path, old_filename)):
-                logger.debug("%s not found" % old_filename)
-            else:
-                logger.debug("%s found" % old_filename)
-                with open(os.path.join(args.inkscape_extensions_path, old_filename)) as f_old, \
-                        open(os.path.join("extension", new_filename)) as f_new:
-                    if f_old.read() != f_new.read():
-                        logger.debug("Content of `%s` are not identical version in distribution" % old_filename)
-                        found_files_to_keep[old_filename] = new_filename
-                    else:
-                        logger.debug("Content of `%s` is identical to distribution" % old_filename)
-
-        files_to_keep = found_files_to_keep
-
-        if len(files_to_keep) > 0:
-            file_s = "file" if len(files_to_keep) == 1 else "files"
-            for old_filename in files_to_keep.keys():
-                logger.warn("Existing `%s` differs from newer version in distribution" % old_filename)
-            args.keep_previous_installation_files = query_yes_no("Keep above %s from previous installation?" % file_s)
-        else:
-            args.keep_previous_installation_files = False
-
-    if not args.keep_previous_installation_files:
-        files_to_keep = {}
-
     if not args.skip_requirements_check:
         check_result = check_requirements()
         if check_result == None:
@@ -739,6 +711,35 @@ if __name__ == "__main__":
             exit(65)
 
     if not args.skip_extension_install:
+
+        if args.keep_previous_installation_files is None:
+            found_files_to_keep = {}
+            for old_filename, new_filename in files_to_keep.iteritems():
+                if not os.path.isfile(os.path.join(args.inkscape_extensions_path, old_filename)):
+                    logger.debug("%s not found" % old_filename)
+                else:
+                    logger.debug("%s found" % old_filename)
+                    with open(os.path.join(args.inkscape_extensions_path, old_filename)) as f_old, \
+                            open(os.path.join("extension", new_filename)) as f_new:
+                        if f_old.read() != f_new.read():
+                            logger.debug("Content of `%s` are not identical version in distribution" % old_filename)
+                            found_files_to_keep[old_filename] = new_filename
+                        else:
+                            logger.debug("Content of `%s` is identical to distribution" % old_filename)
+
+            files_to_keep = found_files_to_keep
+
+            if len(files_to_keep) > 0:
+                file_s = "file" if len(files_to_keep) == 1 else "files"
+                for old_filename in files_to_keep.keys():
+                    logger.warn("Existing `%s` differs from newer version in distribution" % old_filename)
+                args.keep_previous_installation_files = query_yes_no(
+                    "Keep above %s from previous installation?" % file_s)
+            else:
+                args.keep_previous_installation_files = False
+
+        if not args.keep_previous_installation_files:
+            files_to_keep = {}
 
         with TemporaryDirectory() as tmp_dir, \
                 StashFiles(stash_from=args.inkscape_extensions_path,

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ class LoggingColors(object):
         colors = [
             COLOR_RESET,
             BG_DEFAULT + FG_LIGHT_BLUE,
-            BG_DEFAULT + FG_YELLOW,
+            BG_YELLOW + FG_WHITE,
             BG_DEFAULT + FG_RED,
             BG_DEFAULT + FG_GREEN,
             BG_DEFAULT + FG_YELLOW,

--- a/setup.py
+++ b/setup.py
@@ -9,77 +9,86 @@ import shutil
 import subprocess
 import sys
 
-COLOR_RESET = "\033[0m"
 
-def get_levels_colors():
-    RESET = COLOR_RESET
-    FG_DEFAULT = "\033[39m"
-    FG_BLACK = "\033[30m"
-    FG_RED = "\033[31m"
-    FG_GREEN = "\033[32m"
-    FG_YELLOW = "\033[33m"
-    FG_BLUE = "\033[34m"
-    FG_MAGENTA = "\033[35m"
-    FG_CYAN = "\033[36m"
-    FG_LIGHT_GRAY = "\033[37m"
-    FG_DARK_GRAY = "\033[90m"
-    FG_LIGHT_RED = "\033[91m"
-    FG_LIGHT_GREEN = "\033[92m"
-    FG_LIGHT_YELLOW = "\033[93m"
-    FG_LIGHT_BLUE = "\033[94m"
-    FG_LIGHT_MAGENTA = "\033[95m"
-    FG_LIGHT_CYAN = "\033[96m"
-    FG_WHITE = "\033[97m"
+class LoggingColors(object):
 
-    BG_DEFAULT = "\033[49m"
-    BG_BLACK = "\033[40m"
-    BG_RED = "\033[41m"
-    BG_GREEN = "\033[42m"
-    BG_YELLOW = "\033[43m"
-    BG_BLUE = "\033[44m"
-    BG_MAGENTA = "\033[45m"
-    BG_CYAN = "\033[46m"
-    BG_LIGHT_GRAY = "\033[47m"
-    BG_DARK_GRAY = "\033[100m"
-    BG_LIGHT_RED = "\033[101m"
-    BG_LIGHT_GREEN = "\033[102m"
-    BG_LIGHT_YELLOW = "\033[103m"
-    BG_LIGHT_BLUE = "\033[104m"
-    BG_LIGHT_MAGENTA = "\033[105m"
-    BG_LIGHT_CYAN = "\033[106m"
-    BG_WHITE = "\033[107m"
+    enable_colors = True
 
-    levels = [
-        logging.DEBUG,
-        logging.INFO,
-        logging.WARNING,
-        logging.ERROR,
-        logging.ERROR + 1,  # SUCCESS
-        logging.ERROR + 2,  # UNKNOWN
-        logging.CRITICAL
-    ]
-    names = [
-        "DEBUG   ",
-        "INFO    ",
-        "WARNING ",
-        "ERROR   ",
-        "SUCCESS ",
-        "UNKNOWN ",
-        "CRITICAL"
-    ]
-    colors = [
-        RESET,
-        BG_DEFAULT + FG_LIGHT_BLUE,
-        BG_DEFAULT + FG_YELLOW,
-        BG_DEFAULT + FG_RED,
-        BG_DEFAULT + FG_GREEN,
-        BG_DEFAULT + FG_YELLOW,
-        BG_RED + FG_WHITE,
-    ]
-    return {name: (level,color) for level, name, color in zip(levels, names, colors)}
+    def __call__(self):
+        COLOR_RESET = "\033[0m"
+        FG_DEFAULT = "\033[39m"
+        FG_BLACK = "\033[30m"
+        FG_RED = "\033[31m"
+        FG_GREEN = "\033[32m"
+        FG_YELLOW = "\033[33m"
+        FG_BLUE = "\033[34m"
+        FG_MAGENTA = "\033[35m"
+        FG_CYAN = "\033[36m"
+        FG_LIGHT_GRAY = "\033[37m"
+        FG_DARK_GRAY = "\033[90m"
+        FG_LIGHT_RED = "\033[91m"
+        FG_LIGHT_GREEN = "\033[92m"
+        FG_LIGHT_YELLOW = "\033[93m"
+        FG_LIGHT_BLUE = "\033[94m"
+        FG_LIGHT_MAGENTA = "\033[95m"
+        FG_LIGHT_CYAN = "\033[96m"
+        FG_WHITE = "\033[97m"
+
+        BG_DEFAULT = "\033[49m"
+        BG_BLACK = "\033[40m"
+        BG_RED = "\033[41m"
+        BG_GREEN = "\033[42m"
+        BG_YELLOW = "\033[43m"
+        BG_BLUE = "\033[44m"
+        BG_MAGENTA = "\033[45m"
+        BG_CYAN = "\033[46m"
+        BG_LIGHT_GRAY = "\033[47m"
+        BG_DARK_GRAY = "\033[100m"
+        BG_LIGHT_RED = "\033[101m"
+        BG_LIGHT_GREEN = "\033[102m"
+        BG_LIGHT_YELLOW = "\033[103m"
+        BG_LIGHT_BLUE = "\033[104m"
+        BG_LIGHT_MAGENTA = "\033[105m"
+        BG_LIGHT_CYAN = "\033[106m"
+        BG_WHITE = "\033[107m"
+
+        levels = [
+            logging.DEBUG,
+            logging.INFO,
+            logging.WARNING,
+            logging.ERROR,
+            logging.ERROR + 1,  # SUCCESS
+            logging.ERROR + 2,  # UNKNOWN
+            logging.CRITICAL
+        ]
+        names = [
+            "DEBUG   ",
+            "INFO    ",
+            "WARNING ",
+            "ERROR   ",
+            "SUCCESS ",
+            "UNKNOWN ",
+            "CRITICAL"
+        ]
+        colors = [
+            COLOR_RESET,
+            BG_DEFAULT + FG_LIGHT_BLUE,
+            BG_DEFAULT + FG_YELLOW,
+            BG_DEFAULT + FG_RED,
+            BG_DEFAULT + FG_GREEN,
+            BG_DEFAULT + FG_YELLOW,
+            BG_RED + FG_WHITE,
+        ]
+        if not LoggingColors.enable_colors:
+            colors = [""]*len(colors)
+            COLOR_RESET=""
+        return {name: (level, color) for level, name, color in zip(levels, names, colors)}, COLOR_RESET
+
+
+get_levels_colors = LoggingColors()
 
 def colorize_logging():
-    level_colors = get_levels_colors()
+    level_colors, COLOR_RESET = get_levels_colors()
     for name, (level,color) in level_colors.items():
         logging.addLevelName(level, color + name + COLOR_RESET)
 
@@ -188,14 +197,14 @@ class RequirementCheckResult(object):
     @property
     def color(self):
         if self.value == True:
-            return get_levels_colors()["SUCCESS "][1]
+            return get_levels_colors()[0]["SUCCESS "][1]
         elif self.value == False:
-            return get_levels_colors()["ERROR   "][1]
+            return get_levels_colors()[0]["ERROR   "][1]
         else:
-            return get_levels_colors()["UNKNOWN "][1]
+            return get_levels_colors()[0]["UNKNOWN "][1]
 
     def print_to_logger(self, offset=0, prefix="", parent=None):
-        reset_color = COLOR_RESET
+        _, reset_color = get_levels_colors()
         if self.value == True:
             lvl = logging.ERROR + 1  # success
         elif self.value == False:
@@ -205,10 +214,15 @@ class RequirementCheckResult(object):
         else:
             lvl = logging.ERROR + 2  # unknown
 
+        value_repr = {
+            True: "Succ",
+            False: "Fail",
+            None: "Ukwn"
+        }
         if self.nested:
-            nest_symbol = "+"
+            nest_symbol = "+ [%s]" % value_repr[self.value.value]
         else:
-            nest_symbol = "*"
+            nest_symbol = "* [%s]" % value_repr[self.value.value]
 
         if parent:
             if parent.is_and_node:
@@ -489,15 +503,6 @@ def check_requirements():
     return check_result.value
 
 
-colorize_logging()
-logger = logging.getLogger('TexText')
-logger.setLevel(logging.DEBUG)
-ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
-formatter = logging.Formatter('[%(name)s][%(levelname)6s]: %(message)s')
-ch.setFormatter(formatter)
-logger.addHandler(ch)
-
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description='Install TexText')
@@ -539,7 +544,28 @@ if __name__ == "__main__":
         help="Don't install extension"
     )
 
+    parser.add_argument(
+        "--color",
+        default="always",
+        choices=("always", "never"),
+        help="Enables/disable console colors"
+    )
+
     args = parser.parse_args()
+
+    if args.color == "always":
+        LoggingColors.enable_colors = True
+    elif args.color == "never":
+        LoggingColors.enable_colors = False
+
+    colorize_logging()
+    logger = logging.getLogger('TexText')
+    logger.setLevel(logging.DEBUG)
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
+    formatter = logging.Formatter('[%(name)s][%(levelname)6s]: %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
 
     if not args.skip_requirements_check:
         check_result = check_requirements()

--- a/setup.py
+++ b/setup.py
@@ -661,10 +661,10 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--keep-old-preamble",
+        "--keep-previous-installation-files",
         default=None,
         action='store_true',
-        help="Allows installation without prompt"
+        help="Keep/discard files from previous installation, suppress prompt"
     )
 
     parser.add_argument(
@@ -691,18 +691,32 @@ if __name__ == "__main__":
     args = parser.parse_args()
     args.inkscape_extensions_path = os.path.expanduser(args.inkscape_extensions_path)
 
-    if args.keep_old_preamble is None:
-        old_installation_detected = False
-        for f in files_to_keep.keys():
-            if os.path.isfile(os.path.join(args.inkscape_extensions_path,f)):
-                old_installation_detected = True
-                break
-        if old_installation_detected:
-            args.keep_old_preamble = query_yes_no("Keep preamble from previous installation?")
-        else:
-            args.keep_old_preamble = False
+    if args.keep_previous_installation_files is None:
+        found_files_to_keep = {}
+        for old_filename, new_filename in files_to_keep.iteritems():
+            if not os.path.isfile(os.path.join(args.inkscape_extensions_path, old_filename)):
+                logger.debug("%s not found" % old_filename)
+            else:
+                logger.debug("%s found" % old_filename)
+                with open(os.path.join(args.inkscape_extensions_path, old_filename)) as f_old, \
+                        open(os.path.join("extension", new_filename)) as f_new:
+                    if f_old.read() != f_new.read():
+                        logger.debug("Content of `%s` are not identical version in distribution" % old_filename)
+                        found_files_to_keep[old_filename] = new_filename
+                    else:
+                        logger.debug("Content of `%s` is identical to distribution" % old_filename)
 
-    if not args.keep_old_preamble:
+        files_to_keep = found_files_to_keep
+
+        if len(files_to_keep) > 0:
+            file_s = "file" if len(files_to_keep) == 1 else "files"
+            for old_filename in files_to_keep.keys():
+                logger.warn("Existing `%s` differs from newer version in distribution" % old_filename)
+            args.keep_previous_installation_files = query_yes_no("Keep above %s from previous installation?" % file_s)
+        else:
+            args.keep_previous_installation_files = False
+
+    if not args.keep_previous_installation_files:
         files_to_keep = {}
 
     if args.color == "always":
@@ -738,6 +752,5 @@ if __name__ == "__main__":
                 dst=args.inkscape_extensions_path,
                 if_already_exists="overwrite"
             )
-
 
     exit(0)


### PR DESCRIPTION
## Error handling 
 + Added a logfile
 + Top-level error collection 
 + Exceptions are in hierarchy and more telling
 + Don't show same error twice (#17)
 + Suppress additional warning window in kde (missing theme)
 + Reduce `return None -> check for None -> raise` to simple `raise` at first place.

todo: if fatal error is unavoidable show it right away

## setup.py
  + each check marked with Succ/Fail/Ukwn (helpful if terminal does not support colors)
  + add option to suppress console colors
  + remove old installation (if any) by default
  + ask for preamble replacement confirmation iff old file exists and differs
 
## CI
  + added `develop` branch to travis white liest