### PR TITLE
Feature/store gui settings

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -290,7 +290,7 @@ try:
                 else:
                     logger.debug("Using default tex converter `%s` " % current_tex_command)
 
-                gui_wordwrap = self.config.get("gui_wordwrap", TexText.DEFAULT_GUI_WORDWRAP)
+                gui_config = {"word_wrap": self.config.get("gui_wordwrap", TexText.DEFAULT_GUI_WORDWRAP)}
 
                 # Ask for TeX code
                 if self.options.text is None:
@@ -322,7 +322,7 @@ try:
                                                  current_alignment=alignment, current_texcmd=current_tex_command,
                                                  tex_commands=sorted(list(
                                                      self.requirements_checker.available_tex_to_pdf_converters.keys())),
-                                                 word_wrap=gui_wordwrap)
+                                                 gui_config=gui_config)
 
                     def save_callback(_text, _preamble, _scale, alignment=TexText.DEFAULT_ALIGNMENT,
                                  tex_cmd=TexText.DEFAULT_TEXCMD):
@@ -338,10 +338,10 @@ try:
                                                     _tex_command)
 
                     with logger.debug("Run TexText GUI"):
-                        _, _, _, gui_wordwrap = asker.ask(save_callback, preview_callback)
+                        _, _, _, gui_config = asker.ask(save_callback, preview_callback)
 
                     with logger.debug("Saving global GUI settings"):
-                        self.config["gui_wordwrap"] = gui_wordwrap
+                        self.config["gui_wordwrap"] = gui_config["word_wrap"]
                         self.config.save()
 
 

--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -338,7 +338,7 @@ try:
                                                     _tex_command)
 
                     with logger.debug("Run TexText GUI"):
-                        _, _, _, gui_config = asker.ask(save_callback, preview_callback)
+                        gui_config = asker.ask(save_callback, preview_callback)
 
                     with logger.debug("Saving global GUI settings"):
                         self.config["gui_wordwrap"] = gui_config["word_wrap"]

--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -128,7 +128,6 @@ try:
 
         DEFAULT_ALIGNMENT = "middle center"
         DEFAULT_TEXCMD = "pdflatex"
-        DEFAULT_GUI_WORDWRAP = False
 
         def __init__(self):
 
@@ -290,7 +289,8 @@ try:
                 else:
                     logger.debug("Using default tex converter `%s` " % current_tex_command)
 
-                gui_config = {"word_wrap": self.config.get("gui_wordwrap", TexText.DEFAULT_GUI_WORDWRAP)}
+                # GUI related settings start with "gui_"
+                gui_config = {k.split("gui_")[1]:v for k,v in self.config.items() if k.startswith("gui_") and len(k) > 4}
 
                 # Ask for TeX code
                 if self.options.text is None:
@@ -341,7 +341,9 @@ try:
                         gui_config = asker.ask(save_callback, preview_callback)
 
                     with logger.debug("Saving global GUI settings"):
-                        self.config["gui_wordwrap"] = gui_config["word_wrap"]
+                        for key, value in gui_config.items():
+                            # GUI related settings have to start with "gui_"
+                            self.config["gui_%s" % key] = value
                         self.config.save()
 
 

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -903,9 +903,6 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             scale_align_hbox.pack_start(scale_frame, False, False, 0)
             scale_align_hbox.pack_start(alignment_frame, True, True, 0)
 
-            # --- Word wrap box ---
-            self._word_wrap_checkbotton = gtk.CheckButton("Word wrap")
-
             # --- TeX code window ---
             # Scrolling Window with Source View inside
             scroll_window = gtk.ScrolledWindow()
@@ -948,7 +945,6 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
                 action_group.add_toggle_actions(self._toggle_actions, source_view)
                 action_group.add_radio_actions(self._radio_actions, -1, self.tabs_toggled_cb, source_view)
             ui_manager.insert_action_group(action_group, 0)
-            action_group.get_action("WordWrap").connect_proxy(self._word_wrap_checkbotton)
 
             # Menu
             menu = ui_manager.get_widget('/MainMenu')
@@ -968,7 +964,6 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             vbox.pack_start(preamble_frame, False, False, 0)
             vbox.pack_start(texcmd_frame, False, False, 0)
             vbox.pack_start(scale_align_hbox, False, False, 0)
-            vbox.pack_start(self._word_wrap_checkbotton, False, False, 0)
 
             vbox.pack_start(scroll_window, True, True, 0)
             vbox.pack_start(pos_label, False, False, 0)

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -43,7 +43,7 @@ from errors import TexTextCommandFailed, TexTextConversionError
 #   If unsuccessful, try TK
 #   When not even TK could be imported, abort with error message
 try:
-    import pygtk
+    import pygtkx
 
     pygtk.require('2.0')
     import gtk
@@ -413,7 +413,7 @@ if TOOLKIT == TK:
 
             self.callback(self.text, self.preamble_file, self.global_scale_factor, alignment_tk_str.get(),
                           tex_command_tk_str.get())
-            return self.text, self.preamble_file, self.global_scale_factor, {"word_wrap": self._word_wrap_tkval.get()}
+            return {"word_wrap": self._word_wrap_tkval.get()}
 
         def cb_ok(self, widget=None, data=None):
             try:
@@ -1012,5 +1012,4 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
 
                 # main loop
                 gtk.main()
-                return self.text, self.preamble_file, self.global_scale_factor, {
-                    "word_wrap": self._word_wrap_checkbotton.get_active()}
+                return {"word_wrap": self._word_wrap_checkbotton.get_active()}

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -377,23 +377,38 @@ if TOOLKIT == TK:
                     vbox.pack(side="left", fill="x", expand=True)
             box.pack(fill="x")
 
-            # Word wrap
+            # Word wrap status
             self._word_wrap_tkval = Tk.BooleanVar()
             self._word_wrap_tkval.set(self._gui_config.get("word_wrap", self.DEFAULT_WORDWRAP))
-            self._word_wrap_checkbotton = Tk.Checkbutton(self._frame, text="Word wrap", variable=self._word_wrap_tkval,
-                                                         onvalue=True, offvalue=False, command=self.cb_word_wrap)
-            self._word_wrap_checkbotton.pack(pady=2, padx=5, anchor="w")
 
-            # Text input field
-            label = Tk.Label(self._frame, text="Text:")
-            label.pack(pady=2, padx=5, anchor="w")
-            self._text_box = Tk.Text(self._frame)
-            hscrollbar = Tk.Scrollbar(self._frame, orient=Tk.HORIZONTAL, command=self._text_box.xview)
+            # Frame with text input field and word wrap checkbox
+            box = Tk.Frame(self._frame, relief="groove", borderwidth=2)
+            ibox = Tk.Frame(box)
+            label = Tk.Label(ibox, text="LaTeX code:")
+            self._word_wrap_checkbotton = Tk.Checkbutton(ibox, text="Word wrap", variable=self._word_wrap_tkval,
+                                                         onvalue=True, offvalue=False, command=self.cb_word_wrap)
+            label.pack(pady=0, padx=5, side = "left", anchor="w")
+            self._word_wrap_checkbotton.pack(pady=0, padx=5, side = "right", anchor="w")
+            ibox.pack(expand=True, fill="both", pady=0, padx=0)
+
+            ibox = Tk.Frame(box)
+            iibox = Tk.Frame(ibox)
+            self._text_box = Tk.Text(iibox, width=70, height=12) # 70 chars, 12 lines
+            hscrollbar = Tk.Scrollbar(iibox, orient=Tk.HORIZONTAL, command=self._text_box.xview)
             self._text_box["xscrollcommand"]=hscrollbar.set
-            self._text_box.pack(expand=True, fill="both", pady=5, padx=5)
-            hscrollbar.pack(expand=True, fill="both", pady=5, padx=5)
+            self._text_box.pack(expand=True, fill="both", pady=0, padx=1, anchor = "w")
+            hscrollbar.pack(expand=True, fill="both", pady=2, padx=5)
+
+            vscrollbar = Tk.Scrollbar(ibox, orient=Tk.VERTICAL, command=self._text_box.yview)
+            self._text_box["yscrollcommand"]=vscrollbar.set
+            iibox.pack(expand=True, fill="both", pady=0, padx=1, side="left", anchor="e")
+            vscrollbar.pack(expand=True, fill="y", pady=2, padx=1, side = "left", anchor = "e")
+            ibox.pack(expand=True, fill="both", pady=0, padx=5)
+
             self._text_box.insert(Tk.END, self.text)
             self._text_box.configure(wrap=Tk.WORD if self._word_wrap_tkval.get() else Tk.NONE)
+
+            box.pack(fill="x", pady=2)
 
             # OK and Cancel button
             box = Tk.Frame(self._frame)

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -1002,6 +1002,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
                 action.set_active(self._gui_config.get("insert_spaces", self.DEFAULT_INSERTSPACES))
                 action = action_group.get_action('TabsWidth%d' % self._gui_config.get("tab_width", self.DEFAULT_TABWIDTH))
                 action.set_active(True)
+                self._source_view.set_tab_width(action.get_current_value())  # <- Why is this explicit call necessary ??
 
             # Connect event callbacks
             window.connect("key-press-event", self.cb_key_press)

--- a/extension/textext/utility.py
+++ b/extension/textext/utility.py
@@ -169,6 +169,9 @@ class Settings(object):
             return default
         return result
 
+    def items(self):
+        return self.values.items()
+
     def __getitem__(self, key):
         return self.values.get(key)
 


### PR DESCRIPTION
Settings for auto-indent, white-spaces, line-numbers and tabwidth are stored in config, too (see remark in issue #47) 

Use dictionary for passing the options between AskText instances and TexText core, `gui_` is the corresponding prefix in the related keys. Simple, but hopefully enough for our purpose.

I also gave the Tk interface a slightly more compact appearance by reducing the default line number of the TextView widget:
![grafik](https://user-images.githubusercontent.com/11866252/49699114-6e2b5080-fbcd-11e8-95ca-b564ebca503a.png)
