### PR TITLE
fix(requirements check): check against found path, not messages

### DIFF
--- a/extension/textext/requirements_check.py
+++ b/extension/textext/requirements_check.py
@@ -647,7 +647,7 @@ class TexTextRequirementsChecker(object):
                     messages.append("`%s` is found at `%s`" % (exe_name, path))
                     if first_path is None:
                         first_path = path
-            if len(messages) > 0:
+            if first_path is not None:
                 return RequirementCheckResult(True, messages, path=os.path.join(first_path,exe_name))
             messages.append("`%s` is NOT found in PATH" % (exe_name))
         return RequirementCheckResult(False, messages)


### PR DESCRIPTION
Bug appears only when there are multiple executable names and first two names are not found. At first check `messages` gets populated with error message, at second iteration this message treated as success and leads to fault. 