### PR TITLE
Feature/normalize ui rows height

### DIFF
--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -884,15 +884,17 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             preamble_delete.set_tooltip_text("Clear the preamble file setting")
 
             preamble_frame = gtk.Frame("Preamble File")
-            preamble_box = gtk.HBox(homogeneous=False, spacing=2)
+            preamble_box = gtk.HBox(homogeneous=False, spacing=0)
             preamble_frame.add(preamble_box)
-            preamble_box.pack_start(self._preamble_widget, True, True, 2)
-            preamble_box.pack_start(preamble_delete, False, False, 2)
+            preamble_box.pack_start(self._preamble_widget, True, True, 5)
+            preamble_box.pack_start(preamble_delete, False, False, 5)
+            preamble_box.set_border_width(3)
 
             # --- Tex command ---
             texcmd_frame = gtk.Frame("TeX command")
-            texcmd_box = gtk.HBox(homogeneous=False, spacing=2)
+            texcmd_box = gtk.HBox(homogeneous=False, spacing=0)
             texcmd_frame.add(texcmd_box)
+            texcmd_box.set_border_width(3)
 
             self._texcmd_cbox = gtk.combo_box_new_text()
             cell = gtk.CellRendererText()
@@ -902,11 +904,12 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
                 self._texcmd_cbox.append_text(tex_command)
             self._texcmd_cbox.set_active(self.TEX_COMMANDS.index(self.current_texcmd))
             self._texcmd_cbox.set_tooltip_text("TeX command used for compiling.")
-            texcmd_box.pack_start(self._texcmd_cbox, True, True, 2)
+            texcmd_box.pack_start(self._texcmd_cbox, True, True, 5)
 
             # --- Scaling ---
             scale_frame = gtk.Frame("Scale Factor")
-            scale_box = gtk.HBox(homogeneous=False, spacing=2)
+            scale_box = gtk.HBox(homogeneous=False, spacing=0)
+            scale_box.set_border_width(3)
             scale_frame.add(scale_box)
             self._scale_adj = gtk.Adjustment(lower=0.001, upper=180, step_incr=0.001, page_incr=1)
             self._scale = gtk.SpinButton(self._scale_adj)
@@ -954,7 +957,8 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
 
             # --- Alignment box ---
             alignment_frame = gtk.Frame("Alignment")
-            alignment_box = gtk.HBox(homogeneous=False, spacing=2)
+            alignment_box = gtk.HBox(homogeneous=False, spacing=0)
+            alignment_box.set_border_width(3)
             alignment_frame.add(alignment_box)
 
             liststore = gtk.ListStore(str)
@@ -976,9 +980,9 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             alignment_box.pack_start(self._alignment_combobox, True, True, 2)
 
             # --- Scale and alignment together in one "line"
-            scale_align_hbox = gtk.HBox(homogeneous=False, spacing=2)
-            scale_align_hbox.pack_start(scale_frame, False, False, 0)
-            scale_align_hbox.pack_start(alignment_frame, True, True, 0)
+            scale_align_hbox = gtk.HBox(homogeneous=False, spacing=0)
+            scale_align_hbox.pack_start(scale_frame, False, False, 5)
+            scale_align_hbox.pack_start(alignment_frame, True, True, 5)
 
             # --- TeX code window ---
             # Scrolling Window with Source View inside

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -1060,9 +1060,18 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             vbox.pack_start(scroll_window, True, True, 0)
             vbox.pack_start(pos_label, False, False, 0)
             vbox.pack_start(preview_event_box, False, False, 0)
-            vbox.pack_start(self.create_buttons(), False, False, 0)
+            buttons_row = self.create_buttons()
+            vbox.pack_start(buttons_row, False, False, 0)
 
             vbox.show_all()
+
+            self._same_height_objects = [
+                preamble_frame,
+                texcmd_frame,
+                scale_align_hbox,
+                buttons_row
+            ]
+
             self._preview_scroll_window.hide()
 
             # preselect menu check items
@@ -1109,6 +1118,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
                 window = self.create_window()
                 window.set_default_size(500, 500)
                 window.show()
+                self.normalize_ui_row_heights()
 
                 self._window = window
                 self._window.set_focus(self._source_view)
@@ -1116,3 +1126,9 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
                 # main loop
                 gtk.main()
                 return self._gui_config
+
+        def normalize_ui_row_heights(self):
+            heights = [obj.get_allocation().height for obj in self._same_height_objects]
+            max_ui_row_height = max(*heights)
+            for obj in self._same_height_objects:
+                obj.set_size_request(-1, max_ui_row_height)

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -1119,7 +1119,8 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
                 window.set_default_size(500, 500)
                 window.show()
                 self.normalize_ui_row_heights()
-
+                window.hide()
+                window.show()
                 self._window = window
                 self._window.set_focus(self._source_view)
 


### PR DESCRIPTION
Three rows of controls are normalized to same height. Row with Cancel/Preview/Save buttons is NOT resized. I find it decoupled from other three and find it visually more attractive. 

Horizontal spacing is also changed, similarly to #94 

Cancel/Preview/Save buttons row is resized:
![image](https://user-images.githubusercontent.com/2975991/49955493-f5512f00-ff13-11e8-975d-417cf40aa232.png)

Cancel/Preview/Save buttons row is NOT resized:
![image](https://user-images.githubusercontent.com/2975991/49955552-26c9fa80-ff14-11e8-983a-dc986cb82323.png)
