### PR TITLE
fix(requirements check): Ignore decoding errors of subprocess output

### DIFF
--- a/extension/textext/requirements_check.py
+++ b/extension/textext/requirements_check.py
@@ -585,7 +585,7 @@ class TexTextRequirementsChecker(object):
         if version is None:
             return RequirementCheckResult(True, ["ghostscript is found"], path=executable)
 
-        first_stdout_line = stdout.decode("utf-8").split("\n")[0]
+        first_stdout_line = stdout.decode("utf-8", 'ignore').split("\n")[0]
         m = re.search(r"(\d+.\d+)", first_stdout_line)
         if m:
             found_version = m.group(1)
@@ -610,7 +610,7 @@ class TexTextRequirementsChecker(object):
         if version is None:
             return RequirementCheckResult(True, ["pstoedit is found"], path=executable)
 
-        first_stderr_line = stderr.decode("utf-8").split("\n")[0]
+        first_stderr_line = stderr.decode("utf-8", 'ignore').split("\n")[0]
         m = re.search(r"version (\d+.\d+)", first_stderr_line)
         if m:
             found_version = m.group(1)


### PR DESCRIPTION
Nowadays UTF-8 is default encoding on most systems. But there plenty which use other encodings and it's leads to errors in `setup.py` when it interprets external programs output.

Due to lack of encoding detection in minimal distribution of python2.7 the patch simply ignores utf-8 decoding errors. It might lead to "Uknown" requirements check result, but it's better than crash. 

Related issue(s):
#101 

Short checklist:
- [x] Tested with Inkscape version: [any]
- [x] Tested on Linux, Distro: [Ubuntu 18.04]
- [x ] Tested on Windows, Version: [10, 1803]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
