### PR TITLE
Fix Issue 111: Write log file to user-writable dir

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -63,7 +63,9 @@ EXIT_CODE_OK = 0
 EXIT_CODE_EXPECTED_ERROR = 1
 EXIT_CODE_UNEXPECTED_ERROR = 60
 
-LOG_LOCATION = os.path.dirname(__file__)  # todo: check destination is writeable
+LOG_LOCATION = os.path.join(defaults.inkscape_extensions_path, "textext")
+if not os.path.isdir(LOG_LOCATION):
+    os.makedirs(LOG_LOCATION)
 LOG_FILENAME = os.path.join(LOG_LOCATION, "textext.log")  # todo: check destination is writeable
 
 


### PR DESCRIPTION
This should fix Issue #111.

It just changes the location for the log file using the same methods already used for the settings file.

Short checklist:
- [X] Tested with Inkscape version: 0.92
- [X] Tested on Linux, Distro: Arch Linux
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
