### PR TITLE
Fix Issue 111: Write log file to user-writable dir (Develop branch)

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -62,7 +62,9 @@ EXIT_CODE_OK = 0
 EXIT_CODE_EXPECTED_ERROR = 1
 EXIT_CODE_UNEXPECTED_ERROR = 60
 
-LOG_LOCATION = os.path.dirname(__file__)  # todo: check destination is writeable
+LOG_LOCATION = os.path.join(defaults.inkscape_extensions_path, "textext")
+if not os.path.isdir(LOG_LOCATION):
+    os.makedirs(LOG_LOCATION)
 LOG_FILENAME = os.path.join(LOG_LOCATION, "textext.log")  # todo: check destination is writeable
 
 


### PR DESCRIPTION
This should fix Issue #111, rebased to the `develop` branch. Please close one of the two PR's, leaving whichever branch you like better.

It just changes the location for the log file using the same methods already used for the settings file.

Short checklist:
- [X] Tested with Inkscape version: 0.92
- [X] Tested on Linux, Distro: Arch Linux
- [x] Tested on Windows, Version: Windows 10 1809, Inkscape 0.92.3
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
