### PR TITLE
Add instructions to change default inkscape python interpreter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,10 @@
 Version 0.10.2 (2019-05-07)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - New: Disallowed pstoedit 3.73 + ghostscript 9.27 combination during
   installation (:issue_num:`126`)
 
 Version 0.10.1 (2019-04-17)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - Fixed: Inkscape binary not found during installation on some MacOS
   installations (:issue_num:`120`)
 

--- a/docs/source/install/linux.rst
+++ b/docs/source/install/linux.rst
@@ -63,6 +63,14 @@ To install on Ubuntu/Debian:
 
     sudo apt-get install python2.7
 
+
+.. warning::
+
+    On recent systems default python interpreter is ``python3`` which is incompatible with current version of |TexText|.
+    See for instructions :ref:`faq-set-inskscape-python-interpreter-to-python2`.
+
+
+
 .. _linux-install-gui-library:
 
 Install GUI library

--- a/docs/source/usage/faq.rst
+++ b/docs/source/usage/faq.rst
@@ -149,3 +149,49 @@ view of ``stderr`` (see :ref:`trouble_latex`) shows an entry like
 the most likely reason is that MiKTeX tries to install a package on the fly and fails to
 do so. Manually compile your code as described in :ref:`trouble_manual_compile`. Then
 you will see what goes wrong so you can fix it. See also the warning in :ref:`windows-install-latex`.
+
+.. _faq-set-inskscape-python-interpreter-to-python2:
+
+Set Inkscape python interpreter to Python2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Inkscape by default uses ``python`` executable to run python extension. On recent systems ``python`` defaults to be ``python3``.
+To run |TexText| you need to change inkscape `python-interpreter` to ``python2``:
+
+..
+    The steps are taken from
+    http://wiki.inkscape.org/wiki/index.php/Extension_Interpreters#Selecting_a_specific_interpreter_version_.28via_preferences_file.29
+
+
+1. Quit all running Inkscape processes
+
+2. Open your ``perferences.xml`` file with a text editor (usually ``~/.config/inkscape/preferences.xml``)
+
+   .. note::
+
+        Find the exact location of preference file by going to :kbd:`Edit|Preferences|System|User Preferences`
+
+3. Search the group which holds settings for the extension system itself and options of various extensions:
+
+   .. code-block:: xml
+
+      <group
+         id="extensions"
+         …
+         org.ekips.filter.gears.teeth="24"
+         org.ekips.filter.gears.pitch="20"
+         org.ekips.filter.gears.angle="20" />
+
+4. Insert a key for the interpreter, for example 'python-interpreter' for setting the program that should be used to
+   run python extensions, and set the string to the absolute path to the python binary which is compatible with Inkscape's
+   current extension scripts (in the example below, the path is ``/usr/bin/python2.7``):
+
+    .. code-block:: xml
+
+       <group
+          id="extensions"
+          python-interpreter="/usr/bin/python2.7"
+          …
+          org.ekips.filter.gears.teeth="24"
+          org.ekips.filter.gears.pitch="20"
+          org.ekips.filter.gears.angle="20" />


### PR DESCRIPTION
Add instructions to change default inkscape python interpreter

Related issue(s):
#129 

Short checklist: N/A: doc change only 

![image](https://user-images.githubusercontent.com/2975991/57983491-200f5880-7a5b-11e9-890a-68b0ac9a40cc.png)

![image](https://user-images.githubusercontent.com/2975991/57983497-34535580-7a5b-11e9-9b82-91e1e8a96a32.png)
