### PR TITLE
Remove `extension is working` window for inkscape<1.0

### DIFF
--- a/extension/textext.inx
+++ b/extension/textext.inx
@@ -13,4 +13,5 @@
   <script>
     <command reldir="extensions" interpreter="python">textext/__init__.py</command>
   </script>
+  <options silent="true" />
 </inkscape-extension>


### PR DESCRIPTION
As It turns out, there was an undocumented option to hide "extension is working" window. 

- [x] Tested with Inkscape version: Inkscape 0.92.3 (2405546, 2018-03-11)
- [x] Tested on Linux, Distro: Ubuntu 18.04
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]