### PR TITLE
Feature/travis deploy for 1.0 (Stage 1 of 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,15 @@ matrix:
 before_script:
    # Deactivated until tests are rewritten
    #- python -m pip install pytest lxml Pillow
-   - wget -c https://inkscape.org/de/gallery/item/14204/Inkscape-883c7bc-x86_64.AppImage
-   - chmod +x Inkscape-883c7bc-x86_64.AppImage
-   - sudo mv Inkscape-883c7bc-x86_64.AppImage /usr/local/bin
+   - wget -c https://inkscape.org/de/gallery/item/14204/Inkscape-883c7bc-x86_64.AppImage -O ~/bin/inkscape.alpha
+   - chmod +x ~/bin/inkscape.alpha
+   - export PATH=~/bin:$PATH
    - python test_installation_script.py 2> /dev/null
    - python setup.py
 
 
 script:
-  - export PYTHONPATH="`Inkscape-883c7bc-x86_64.AppImage -x`:$HOME/.config/inkscape/extensions/"
+  - export PYTHONPATH="`inkscape.alpha -x`:$HOME/.config/inkscape/extensions/"
   #- python -m pytest --verbose -s pytests
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
-python: '2.7'
+python: '3.6'
 
 branches:
   only:
   - master
   - develop
-  - feature/add_travis_deploy
+  - feature/travis_deploy_for_1.0
 
 virtualenv:
   system_site_packages: true
@@ -13,40 +13,32 @@ virtualenv:
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: bionic
       addons:
         apt:
           packages:
-          - pstoedit
-          - pdf2svg
-          - inkscape
-          - python-gtk2-dev
-          - imagemagick
-          - texlive-latex-base
-
-    - os: linux
-      dist: xenial
-      addons:
-        apt:
-          packages:
-          - pstoedit
-          - pdf2svg
-          - inkscape
-          - python-gtk2-dev
-          - imagemagick
+          # Will still load inkscape 0.92.x, hence use manual app image, see below
+          #- inkscape
+          - python3-gi
+          - python3-gi-cairo
+          - gir1.2-gtk-3.0
           - texlive-latex-base
       env:
         - RELEASE_MAKER=true
 
 before_script:
-   - python2 -m pip install pytest lxml Pillow
-   - python2 test_installation_script.py 2> /dev/null
-   - python2 setup.py
+   # Deactivated until tests are rewritten
+   #- python -m pip install pytest lxml Pillow
+   - wget -c https://inkscape.org/de/gallery/item/14204/Inkscape-883c7bc-x86_64.AppImage
+   - chmod +x Inkscape-883c7bc-x86_64.AppImage
+   - sudo mv Inkscape-883c7bc-x86_64.AppImage /usr/local/bin
+   - python test_installation_script.py 2> /dev/null
+   - python setup.py
 
 
 script:
-  - export PYTHONPATH="`inkscape -x`:$HOME/.config/inkscape/extensions/"
-  - python2 -m pytest --verbose -s pytests
+  - export PYTHONPATH="`Inkscape-883c7bc-x86_64.AppImage -x`:$HOME/.config/inkscape/extensions/"
+  #- python -m pytest --verbose -s pytests
 
 after_success:
   - VERSION_CHANGED=$(git diff --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep -q extension/textext/VERSION; echo $?;)
@@ -76,7 +68,7 @@ after_success:
 
 before_deploy:
   - bash build_docs.sh
-  - python2 build_packages.py
+  - python build_packages.py
   - git config --global user.email "builds@travis-ci.com"
   - git config --global user.name "Travis CI"
 

--- a/extension/textext/requirements_check.py
+++ b/extension/textext/requirements_check.py
@@ -33,7 +33,7 @@ class LinuxDefaults(Defaults):
     os_name = "linux"
     console_colors = "always"
     #executable_names = {"inkscape": ["inkscape"],
-    executable_names = {"inkscape": ["Inkscape-883c7bc-x86_64.AppImage", "inkscape"],   # ALPHA-TEST only #
+    executable_names = {"inkscape": ["inkscape.alpha", "inkscape"],   # ALPHA-TEST only #
                         "pdflatex": ["pdflatex"],
                         "lualatex": ["lualatex"],
                         "xelatex": ["xelatex"]

--- a/extension/textext/requirements_check.py
+++ b/extension/textext/requirements_check.py
@@ -32,7 +32,8 @@ class Defaults(object):
 class LinuxDefaults(Defaults):
     os_name = "linux"
     console_colors = "always"
-    executable_names = {"inkscape": ["inkscape"],
+    #executable_names = {"inkscape": ["inkscape"],
+    executable_names = {"inkscape": ["Inkscape-883c7bc-x86_64.AppImage", "inkscape"],   # ALPHA-TEST only #
                         "pdflatex": ["pdflatex"],
                         "lualatex": ["lualatex"],
                         "xelatex": ["xelatex"]
@@ -561,17 +562,17 @@ class TexTextRequirementsChecker(object):
             stdout, stderr = defaults.call_command([executable, "--version", "import Tkinter; import tkMessageBox; import tkFileDialog;"])
         except (KeyError, OSError):
             return RequirementCheckResult(False, ["inkscape is not found"])
-        first_stdout_line = stdout.decode("utf-8", 'ignore').split("\n")[0]
-        print(first_stdout_line)
-        m = re.search(r"Inkscape (\d+.\d+\w+)", first_stdout_line)
+        for stdout_line in stdout.decode("utf-8", 'ignore').split("\n"):
+            print(stdout_line)
+            m = re.search(r"Inkscape (\d+.\d+\w+)", stdout_line)
 
-        if m:
-            found_version = m.group(1)
-            if LooseVersion(found_version) >= LooseVersion("1.0"):
-                return RequirementCheckResult(True, ["inkscape=%s is found" % found_version], path=executable)
-            else:
-                return RequirementCheckResult(False, [
-                    "inkscape>=1.0 is not found (but inkscape=%s is found)" % (found_version)])
+            if m:
+                found_version = m.group(1)
+                if LooseVersion(found_version) >= LooseVersion("1.0"):
+                    return RequirementCheckResult(True, ["inkscape=%s is found" % found_version], path=executable)
+                else:
+                    return RequirementCheckResult(False, [
+                        "inkscape>=1.0 is not found (but inkscape=%s is found)" % (found_version)])
         return RequirementCheckResult(None, ["Can't determinate inkscape version"])
 
     def find_executable(self, prog_name):

--- a/test_installation_script.py
+++ b/test_installation_script.py
@@ -58,6 +58,8 @@ def test_configuration(fake_commands, expected_exit_code):
                                    env=env
                                    )
         assert ret_code == expected_exit_code, '%d != %d' % (ret_code, expected_exit_code)
+        print("\033[92m  ====> Test %s successfully with expected exit code %d passed!\033[0m\n" % (
+            fake_commands, expected_exit_code))
 
 
 REQUIREMENT_CHECK_SUCCESS = 0
@@ -66,16 +68,8 @@ REQUIREMENT_CHECK_ERROR = 65
 
 good_configurations = []
 
-for pdf2svg in [[("pstoedit", "version 1.1", "stderr"),
-                 ("ghostscript", "9.25")
-                 ],
-                [("pdf2svg",)]
-                ]:
-    for latex in [("pdflatex",), ("lualatex",), ("xelatex",)]:
-        good_configurations.append([
-                                       ("inkscape",),
-                                       latex
-                                   ] + pdf2svg)
+for latex in [("pdflatex",), ("lualatex",), ("xelatex",)]:
+    good_configurations.append([("inkscape", "Inkscape 1.0alpha2 (883c7bc, 2019-06-02)"), latex])
 
 for good_configuration in good_configurations:
     test_configuration(good_configuration, REQUIREMENT_CHECK_SUCCESS)
@@ -84,32 +78,26 @@ for good_configuration in good_configurations:
     for i in range(len(good_configuration)):
         # good configuration without one element is bad
         bad_configuration = good_configuration[:i] + good_configuration[i + 1:]
+        print(bad_configuration)
         test_configuration(bad_configuration, REQUIREMENT_CHECK_ERROR)
 
 test_configuration([
-    ("inkscape",),
+    ("inkscape", "Inkscape 0.92.3 (2405546, 2018-03-11)"),
+], REQUIREMENT_CHECK_ERROR)
+
+test_configuration([
+    ("inkscape", "Inkscape 0.92.3 (2405546, 2018-03-11)"),
+    ("pdflatex",)
 ], REQUIREMENT_CHECK_ERROR)
 
 test_configuration([
     ("inkscape",),
     ("pdflatex",),
-    ("pstoedit", "version 3.70", "stderr"),
-    ("ghostscript", "9.22")
-], REQUIREMENT_CHECK_ERROR)
-
-test_configuration([
-    ("inkscape",),
-    ("pdflatex",),
-    ("pstoedit",),
-    ("ghostscript",)
 ], REQUIREMENT_CHECK_UNKNOWN)
 
 test_configuration([
-    ("inkscape",),
+    ("inkscape", "Inkscape 1.0alpha2 (883c7bc, 2019-06-02)"),
     ("pdflatex",),
-    ("pstoedit",),
-    ("ghostscript",),
-    ("pdf2svg",)
 ], REQUIREMENT_CHECK_SUCCESS)
 
 test_configuration([


### PR DESCRIPTION
This pull request is the first of two for re-enabling travis ci tests.

In this stage an app image of the alpha2 version of Inkscape is installed in the build machine and the installation procedure is tested. The next stage will re-enable the compatibility tests (or at least introduce a simple functional test).

Note: I wanted to have Inkscape 0.92.x and 1.0alpha2 in parallel on my test-machine. Hence I har-coded the alpha2 name and some places which is not very elegant but maybe OK for this test phase...