### PR TITLE
Remove a print statement from requirements_checker

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -229,8 +229,6 @@ try:
                 # Find root element
                 old_svg_ele, text, preamble_file, current_scale = self.get_old()
 
-                # print(old_svg_ele)
-
                 alignment = TexText.DEFAULT_ALIGNMENT
 
                 preferred_tex_cmd = self.config.get("previous_tex_command", TexText.DEFAULT_TEXCMD)

--- a/extension/textext/requirements_check.py
+++ b/extension/textext/requirements_check.py
@@ -563,7 +563,7 @@ class TexTextRequirementsChecker(object):
         except (KeyError, OSError):
             return RequirementCheckResult(False, ["inkscape is not found"])
         for stdout_line in stdout.decode("utf-8", 'ignore').split("\n"):
-            print(stdout_line)
+            #print(stdout_line)
             m = re.search(r"Inkscape (\d+.\d+\w+)", stdout_line)
 
             if m:

--- a/extension/textext/requirements_check.py
+++ b/extension/textext/requirements_check.py
@@ -32,7 +32,6 @@ class Defaults(object):
 class LinuxDefaults(Defaults):
     os_name = "linux"
     console_colors = "always"
-    #executable_names = {"inkscape": ["inkscape"],
     executable_names = {"inkscape": ["inkscape.alpha", "inkscape"],   # ALPHA-TEST only #
                         "pdflatex": ["pdflatex"],
                         "lualatex": ["lualatex"],
@@ -416,7 +415,6 @@ class Requirement(object):
 
     def check(self):
         result = self.criteria()
-        # print(self,self._overwrite_messages)
         if not isinstance(result.messages,list):
             result.messages = [result.messages]
         if self._overwrite_messages:
@@ -442,7 +440,6 @@ class Requirement(object):
             result.messages += self._appended_messages["ERROR"]
         if result.value == TrinaryLogicValue(None):
             result.messages += self._appended_messages["UNKNOWN"]
-        # print(self,result.messages)
         return result
 
     def prepend_message(self, result_type, message):
@@ -563,7 +560,6 @@ class TexTextRequirementsChecker(object):
         except (KeyError, OSError):
             return RequirementCheckResult(False, ["inkscape is not found"])
         for stdout_line in stdout.decode("utf-8", 'ignore').split("\n"):
-            #print(stdout_line)
             m = re.search(r"Inkscape (\d+.\d+\w+)", stdout_line)
 
             if m:


### PR DESCRIPTION
# Context

A `print` statement, presumably used for debugging during development, found its way into the release. This results in the found version of Inkscape being the first bit of text sent back.

Inkscape may be able to handle this if valid content follows, but it upsets it if its the only thing returned (try just clicking cancel after opening the extension--you'll get an error).

This simply comments out that print statement, following the style in the rest of the file.

# Checklist

- [x] Tested with Inkscape version: [development]
- [x] Tested on Linux, Distro: [Debian]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
