### PR TITLE
Support `<defs>`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,13 @@ def query_yes_no(question, default="yes"):
         prompt = " [y/N] "
     else:
         raise ValueError("invalid default answer: '%s'" % default)
-
+    if sys.version_info[0] > 2:
+        read_input = input
+    else:
+        read_input = raw_input
     while True:
         sys.stdout.write(question + prompt)
-        choice = raw_input().lower()
+        choice = read_input().lower()
         if default is not None and choice == '':
             return valid[default]
         elif choice in valid:


### PR DESCRIPTION
Related issue(s):
   #148 

Precise description of the changes proposed in the pull request:
  - fix interactive install with python3
  - embed `<defs>` tag in textext object

An alternative implementation with populating root `<defs>` would result to buggy copy to another document and potential pollution of root `<defs>`. 

Currently I'm not satisfied with id replacement performance. It takes 8 seconds on my machine on  first example from #148, therefore I mark the PR as a draft for now.

Short checklist:
- [x] Tested with Inkscape version: [ Inkscape 1.0beta1 (e7e369847f, 2019-11-25) ]
- [x] Tested on Linux, Distro: [ Ubuntu 18.04.1 LTS ]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]

**Edit:** update tested inkscape version