### PR TITLE
Backwards compatible python 3 changes

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -559,7 +559,7 @@ try:
                         parsed_log = self.parse_pdf_log(self.tmp('log'))
                         raise TexTextConversionError(parsed_log, error.return_code, error.stdout, error.stderr)
                     else:
-                        raise TexTextConversionError(error.message, error.return_code, error.stdout, error.stderr)
+                        raise TexTextConversionError(str(error), error.return_code, error.stdout, error.stderr)
 
                 if not os.path.exists(self.tmp('pdf')):
                     raise TexTextConversionError("%s didn't produce output %s" % (tex_command, self.tmp('pdf')))

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -158,9 +158,9 @@ def error_dialog(parent, title, label, error):
 
     if isinstance(error, (TexTextConversionError, TexTextCommandFailed)):
         if error.stdout:
-            add_section("Stdout: <small><i>(click to expand)</i></small>", error.stdout)
+            add_section("Stdout: <small><i>(click to expand)</i></small>", error.stdout.decode('utf-8'))
         if error.stderr:
-            add_section("Stderr: <small><i>(click to expand)</i></small>", error.stderr)
+            add_section("Stderr: <small><i>(click to expand)</i></small>", error.stderr.decode('utf-8'))
     dialog.show_all()
     dialog.run()
 

--- a/extension/textext/errors.py
+++ b/extension/textext/errors.py
@@ -1,7 +1,6 @@
 
 class TexTextError(RuntimeError):
     """ Basic class of all TexText errors"""
-    pass
 
 
 class TexTextNonFatalError(TexTextError):

--- a/extension/textext/latexlogparser.py
+++ b/extension/textext/latexlogparser.py
@@ -26,7 +26,6 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import re
-import string
 
 import codecs
 
@@ -104,7 +103,7 @@ class LogCheck(object):
                 # sometimes issues warnings (like undefined references) in the
                 # form of errors...
 
-                if string.find(line, "pdfTeX warning") == -1:
+                if line.find("pdfTeX warning") == -1:
                     return True
         return False
 
@@ -186,7 +185,7 @@ class LogCheck(object):
                 if m:
                     parsing = False
                     skipping = True
-                    pdfTeX = string.find(line, "pdfTeX warning") != -1
+                    pdfTeX = line.find("pdfTeX warning") != -1
                     if (pdfTeX and warnings) or (errors and not pdfTeX):
                         if pdfTeX:
                             d = {
@@ -248,7 +247,7 @@ class LogCheck(object):
 
             if prefix is not None:
                 if line[:len(prefix)] == prefix:
-                    text.append(string.strip(line[len(prefix):]))
+                    text.append(line[len(prefix):].strip())
                 else:
                     text = " ".join(text)
                     m = re_online.search(text)


### PR DESCRIPTION
## Related issue(s):
This is one of the two patches in #146.

## Precise description of the changes proposed in the pull request:

This patch handles unicode changes and changes to functionality in the `string` module. **These changes should be backwards compatible to (at least) python 2.7.12**.

## Short checklist:
- [x] Tested with Inkscape version: [develop]
- [x] Tested on Linux, Distro: [Debian]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
