### PR TITLE
Doc: Install instructions for Inkscape 1.0

### DIFF
--- a/docs/source/install/linux-beta.rst
+++ b/docs/source/install/linux-beta.rst
@@ -1,0 +1,100 @@
+.. |TexText| replace:: **TexText for Inkscape 1.0 beta**
+.. |Inkscape| replace:: **Inkscape 1.0 beta**
+
+.. role:: bash(code)
+   :language: bash
+   :class: highlight
+
+.. role:: latex(code)
+   :language: latex
+   :class: highlight
+
+.. _linux-beta-install:
+
+==================
+|TexText| on Linux
+==================
+
+This guide explains how to install and use |TexText| together with |Inkscape| on a system
+on which also Inkscape 0.94.x is installed.
+
+Preparation
+===========
+
+1. Backup your existing Inkscape extension directory
+
+    .. code-block:: bash
+
+        cp -r ~/.config/inkscape/extensions ~/.config/inkscape/extensions.backup
+
+2. Remove the old TexText installation:
+
+    .. code-block:: bash
+
+        rm -rf ~/.config/inkscape/extensions/textext
+        rm ~/.config/inkscape/extensions/textext.inx
+
+
+Download and install the |Inkscape| app image file
+==================================================
+
+1. You can download |Inkscape| from https://inkscape.org/release/inkscape-1.0beta1/. Or
+   execute
+
+    .. code-block:: bash
+
+        wget -c https://inkscape.org/gallery/item/14918/Inkscape-fe3e306-x86_64.AppImage
+
+2. Make the downloaded AppImage executable:
+
+    .. code-block:: bash
+
+        chmod u+x Inkscape-fe3e306-x86_64.AppImage
+
+3. Extract the AppImage:
+
+    .. code-block:: bash
+
+        ./Inkscape-fe3e306-x86_64.AppImage --appimage-extract
+
+After this operation |Inkscape| will reside in ``~/squashfs-root/bin``. You can test it by
+executing
+
+.. code-block:: bash
+
+    ~/squashfs-root/bin/inkscape &
+
+
+Download and install |TexText|
+==============================
+
+1. Download the most recent **preview** package from https://github.com/textext/textext/releases
+2. Extract the package and change to the created directory.
+3. Run :bash:`setup.py` with (**Important!!**) specification of the path to your |Inkscape| executable
+   from your terminal:
+
+    .. code-block:: bash
+
+        python3 setup.py --inkscape-executable ~/squashfs-root/bin/inkscape
+
+    Setup will inform you if some of the prerequisites needed by |TexText| are missing.
+    Install them.
+
+    .. important::
+
+        Compared to previous versions of **TexText** for Inkscape 0.94.x |TexText| does
+        not need any conversion utilities like ghostscript, pstoedit or pdfsvg.
+
+Now you can launch |Inkscape| by typing :bash:`~/squashfs-root/bin/inkscape &` and work
+with |TexText|
+
+Please report any issues! Thank you!
+
+
+Switching back to Inkscape 0.94.x
+=================================
+
+.. code-block:: bash
+
+    mv ~/.config/inkscape/extensions ~/.config/inkscape/extensions.beta
+    cp -r ~/.config/inkscape/extensions.backup/ ~/.config/inkscape/extensions

--- a/docs/source/install/linux-beta.rst
+++ b/docs/source/install/linux-beta.rst
@@ -45,7 +45,7 @@ Download and install the |Inkscape| app image file
 
         wget -c https://inkscape.org/gallery/item/14918/Inkscape-fe3e306-x86_64.AppImage
 
-2. Make the downloaded AppImage executable:
+2. Change into the directory into which you downloaded the AppImage. Then, make it executable:
 
     .. code-block:: bash
 
@@ -56,6 +56,13 @@ Download and install the |Inkscape| app image file
     .. code-block:: bash
 
         ./Inkscape-fe3e306-x86_64.AppImage --appimage-extract
+
+4. Optional, if you are not in your home directory: Move the created directory ``squashfs-root``
+   into your home directory:
+
+    .. code-block:: bash
+
+        mv squashfs-root ~
 
 After this operation |Inkscape| will reside in ``~/squashfs-root/bin``. You can test it by
 executing
@@ -69,7 +76,7 @@ Download and install |TexText|
 ==============================
 
 1. Download the most recent **preview** package from https://github.com/textext/textext/releases
-2. Extract the package and change to the created directory.
+2. Extract the package and change into the created directory.
 3. Run :bash:`setup.py` with (**Important!!**) specification of the path to your |Inkscape| executable
    from your terminal:
 

--- a/docs/source/install/linux.rst
+++ b/docs/source/install/linux.rst
@@ -10,9 +10,14 @@
 
 .. _linux-install:
 
-================
-TexText on Linux
-================
+====================================
+TexText for Inkscape 0.94.x on Linux
+====================================
+
+.. important::
+
+    If you would like to try out |TexText| on Inkscape 1.0 beta please use this installation guide:
+    :ref:`linux-beta-install`!
 
 To install |TexText| on Linux do the following steps:
 

--- a/docs/source/install/windows-beta.rst
+++ b/docs/source/install/windows-beta.rst
@@ -1,0 +1,93 @@
+.. |TexText| replace:: **TexText for Inkscape 1.0 beta**
+.. |Inkscape| replace:: **Inkscape 1.0 beta**
+
+.. role:: bash(code)
+   :language: bash
+   :class: highlight
+
+.. role:: latex(code)
+   :language: latex
+   :class: highlight
+
+.. _windows-beta-install:
+
+====================
+|TexText| on Windows
+====================
+
+This guide explains how to install and use |TexText| together with |Inkscape| on a system
+on which also Inkscape 0.94.x is installed.
+
+.. note::
+
+    Several of the following actions take place in a command window. To open a
+    command window from the Windows Explorer ``right click`` while pressing the ``SHIFT`` key in
+    the directory you want to open it. Then select ``Open command window here``.
+
+Preparation
+===========
+In a command window execute the following steps:
+
+1. Backup your existing Inkscape extension directory:
+
+    .. code-block:: winbatch
+
+        xcopy /S /E /Y %APPDATA%\inkscape\extensions %APPDATA%\inkscape\extensions.backup\
+
+2. Remove the old TexText installation:
+
+    .. code-block:: winbatch
+
+        del /S /Q %APPDATA%\inkscape\extensions\textext
+        del /Q %APPDATA%\inkscape\extensions\textext.inx
+
+
+Download and install the |Inkscape| app image file
+==================================================
+
+1. Download |Inkscape| from https://inkscape.org/release/inkscape-1.0beta1/.
+
+2. Extract the zip package to a folder of your choice, e.g. ``C:\InkscapeBeta``.
+
+3. Veryify that you are able to launch |Inkscape| by double clicking on ``inkscape.exe``
+   in ``C:\InkscapeBeta\bin``.
+
+
+Download and install |TexText|
+==============================
+
+1. Download the most recent **preview** package from https://github.com/textext/textext/releases
+2. Extract the package and change into the created directory.
+3. In a command window run :bash:`setup_win.bat` with (**Important!!**) specification of the
+   path to your |Inkscape| executable from your terminal:
+
+    .. code-block:: winbatch
+
+        setup_win.bat /d:"C:\InkscapeBeta\bin"
+
+    Setup will inform you if some of the prerequisites needed by |TexText| are missing.
+    Install them.
+
+    .. important::
+
+        1. Compared to previous versions of **TexText** for Inkscape 0.94.x |TexText| does
+           not need any conversion utilities like ghostscript, pstoedit or pdfsvg.
+
+        2. Currently, GTKSourceView is not available in the Windows version of |TexText|, hence
+           syntax highlighting is not enabled.
+
+Now you can launch |Inkscape| by double clicking on ``inkscape.exe`` in ``C:\InkscapeBeta``
+and work with |TexText|
+
+Please report any issues! Thank you!
+
+
+Switching back to Inkscape 0.94.x
+=================================
+
+In a command window execute:
+
+.. code-block:: winbatch
+
+    move /Y %APPDATA%\inkscape\extensions %APPDATA%\inkscape\extensions.beta\
+    xcopy /S /E /Y %APPDATA%\inkscape\extensions.backup %APPDATA%\inkscape\extensions\

--- a/docs/source/install/windows.rst
+++ b/docs/source/install/windows.rst
@@ -10,9 +10,9 @@
 
 .. _windows-install:
 
-==================
-TexText on Windows
-==================
+======================================
+TexText for Inkscape 0.94.x on Windows
+======================================
 
 To install |TexText| on Windows do the following steps:
 


### PR DESCRIPTION
I would like to provide instructions on how to test current development version of TexText with Inkscape 1.0 beta while Inkscape 0.94.x is also installed and on the system path.

This PR offers instructions for Linux, as I use it. You can see it here: 

https://jcwinkler.github.io/textext/install/linux-beta.html

Windows will follow.

If some more convenient ways are possible please let me know. Thanks!