### PR TITLE
Feature/preview shortcut

### DIFF
--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -700,6 +700,9 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
 
         def close_shortcut_cb(self, action, previous_value, sourceview):
             self._gui_config["close_shortcut"] = self.CLOSE_SHORTCUT[action.get_current_value()]
+            self._cancel_button.set_tooltip_text(
+                "Don't save changes ({})".format(self._close_shortcut_actions[action.get_current_value()][2]).replace(
+                    "_", ""))
 
         def confirm_close_toggled_cb(self, action, sourceview):
             self._gui_config["confirm_close"] = action.get_active()
@@ -904,15 +907,15 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             button_box.set_spacing(spacing)
 
             self._cancel_button = Gtk.Button(stock=Gtk.STOCK_CANCEL)
-            self._cancel_button.set_tooltip_text("Don't save changes")
+            self._cancel_button.set_tooltip_text("Don't save changes (ESC)")
             button_box.add(self._cancel_button)
 
             self._preview_button = Gtk.Button(label="Preview")
-            self._preview_button.set_tooltip_text("You need ImageMagick for previews to work")
+            self._preview_button.set_tooltip_text("Show/ update preview (CTRL+P)")
             button_box.add(self._preview_button)
 
             self._ok_button = Gtk.Button(stock=Gtk.STOCK_SAVE)
-            self._ok_button.set_tooltip_text("Update or create new LaTeX output")
+            self._ok_button.set_tooltip_text("Update or create new LaTeX output (CTRL+RETURN)")
             button_box.add(self._ok_button)
 
             self._cancel_button.connect("clicked", self.cb_cancel)

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -716,6 +716,11 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
                 self._ok_button.clicked()
                 return True
 
+            # Show/ update Preview shortcut (CTRL+P)
+            if Gdk.keyval_name(event.keyval) == 'p' and Gdk.ModifierType.CONTROL_MASK and event.state:
+                self._preview_button.clicked()
+                return True
+
             # Cancel dialog via shortcut if set by the user
             close_shortcut_value = self._gui_config.get("close_shortcut", self.DEFAULT_CLOSE_SHORTCUT)
             if close_shortcut_value is not 'None':
@@ -902,9 +907,9 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             self._cancel_button.set_tooltip_text("Don't save changes")
             button_box.add(self._cancel_button)
 
-            preview_button = Gtk.Button(label="Preview")
-            preview_button.set_tooltip_text("You need ImageMagick for previews to work")
-            button_box.add(preview_button)
+            self._preview_button = Gtk.Button(label="Preview")
+            self._preview_button.set_tooltip_text("You need ImageMagick for previews to work")
+            button_box.add(self._preview_button)
 
             self._ok_button = Gtk.Button(stock=Gtk.STOCK_SAVE)
             self._ok_button.set_tooltip_text("Update or create new LaTeX output")
@@ -912,7 +917,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
 
             self._cancel_button.connect("clicked", self.cb_cancel)
             self._ok_button.connect("clicked", self.cb_ok)
-            preview_button.connect('clicked', self.update_preview)
+            self._preview_button.connect('clicked', self.update_preview)
 
             return button_box
 


### PR DESCRIPTION
This PR adds a shortcut for the preview. Furthermore, the shortcuts are shown in the tooltip of the corresponding buttons now. Since the can vary for the cancel operation some handling is required.

Related issue(s): #134

Short checklist:
- [x] Tested with Inkscape version: 1.0 beta1 (Python 2.7 and 3.7)
- [x] Tested on Linux, Distro: Kubuntu 18.04
- [x] Tested on Windows, Version: 8.1
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
