### PR TITLE
Hotfix: Illegal string comparison

### DIFF
--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -718,7 +718,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
 
             # Cancel dialog via shortcut if set by the user
             close_shortcut_value = self._gui_config.get("close_shortcut", self.DEFAULT_CLOSE_SHORTCUT)
-            if close_shortcut_value is not 'None':
+            if close_shortcut_value != 'None':
                 if (close_shortcut_value == 'Escape' and Gdk.keyval_name(event.keyval) == 'Escape') or \
                    (close_shortcut_value == 'CtrlQ' and Gdk.keyval_name(event.keyval) == 'q' and
                     Gdk.ModifierType.CONTROL_MASK and event.state):

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -718,12 +718,11 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
 
             # Cancel dialog via shortcut if set by the user
             close_shortcut_value = self._gui_config.get("close_shortcut", self.DEFAULT_CLOSE_SHORTCUT)
-            if close_shortcut_value != 'None':
-                if (close_shortcut_value == 'Escape' and Gdk.keyval_name(event.keyval) == 'Escape') or \
-                   (close_shortcut_value == 'CtrlQ' and Gdk.keyval_name(event.keyval) == 'q' and
-                    Gdk.ModifierType.CONTROL_MASK and event.state):
-                    self._cancel_button.clicked()
-                    return True
+            if (close_shortcut_value == 'Escape' and Gdk.keyval_name(event.keyval) == 'Escape') or \
+               (close_shortcut_value == 'CtrlQ' and Gdk.keyval_name(event.keyval) == 'q' and
+                Gdk.ModifierType.CONTROL_MASK and event.state):
+                self._cancel_button.clicked()
+                return True
 
             return False
 


### PR DESCRIPTION
Since Python 3.8 a warning is thrown in constructs like

if x is not 'None'

with x being a string since this is not an comparison between objects. (Python 3.8 is new interpreter in Inkscape beta 2 on Windows...)

