### PR TITLE
Hotfix: "RuntimeError: dictionary changed size during iteration"

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -342,7 +342,7 @@ try:
 
             with logger.debug("TexText.preview"):
                 with logger.debug("args:"):
-                    for k, v in locals().items():
+                    for k, v in list(locals().items()):
                         logger.debug("%s = %s" % (k, repr(v)))
 
                 if not text:
@@ -377,7 +377,7 @@ try:
 
             with logger.debug("TexText.do_convert"):
                 with logger.debug("args:"):
-                    for k, v in locals().items():
+                    for k, v in list(locals().items()):
                         logger.debug("%s = %s" % (k, repr(v)))
 
                 if not text:


### PR DESCRIPTION
During debugging in PyCharm ``for k, v in locals().items():`` throws
the RuntimeError exception "Dictionary changed size during iteration".

I guess it is because locals() is modified by the IDE or something else.
With the provided fix the problem is solved.

Short checklist:
- [x] Tested with Inkscape version: 1.0beta2
- [x] Tested on Linux, Distro: Kubuntu 18.04 with Inkscape using Python 2.7
- [x] Tested on Windows 8.1 with Inkscape using Python 3.8
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
