### PR TITLE
Hotfix: Scale factor is ignored in new nodes

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -424,8 +424,9 @@ try:
                         height = self.svg.unittouu(self.get_document_height())
 
                         x, y, w, h = tt_node.bounding_box()
-                        tt_node.transform = Transform(tt_node.transform) * Transform(translate=(-x + width / 2 - w / 2,
-                                                                                              -y + height / 2 - h / 2))
+                        tt_node.transform = tt_node.transform * \
+                                            Transform(translate=(-x + width / 2 - w / 2, -y + height / 2 - h / 2)) * \
+                                            Transform(scale=scale_factor)
                         tt_node.set_meta('jacobian_sqrt', str(tt_node.get_jacobian_sqrt()))
 
                         self.svg.get_current_layer().add(tt_node)


### PR DESCRIPTION
**Before:**

![grafik](https://user-images.githubusercontent.com/11866252/71086730-d9bddb80-219a-11ea-9f29-3b39c0796213.png)

**After:**

![grafik](https://user-images.githubusercontent.com/11866252/71086748-e7736100-219a-11ea-91a1-5e1697a7d293.png)

In both cases scale factor 1.0 is used.