### PR TITLE
Fixed: Inkscape version never stored in TexText node

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -409,8 +409,8 @@ try:
                 tt_node.set_meta("alignment", str(alignment))
 
                 try:
-                    inkscape_version = self.svg.getroot().get('version')
-                    tt_node.set("inkscapeversion", inkscape_version.split(' ')[0])
+                    inkscape_version = self.document.getroot().get('inkscape:version')
+                    tt_node.set_meta("inkscapeversion", inkscape_version.split(' ')[0])
                 except AttributeError as ignored:
                     # Unfortunately when this node comes from an Inkscape document that has never been saved before
                     # no version attribute is provided by Inkscape :-(


### PR DESCRIPTION
Since exception thrown when acessing nonexising self.svg member
is silently ignored, the error did not show up during testing.

Furthermore the correct tag to query for is inkscape:version, not
version (have we been in the inkscape namespace by default in old
TexText verions?)

Finally set_meta is called instead of set so that namespace is correctly
set.

Short checklist:
- [x] Tested with Inkscape version: 1.0.0 beta2
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [x] Tested on Windows 8.1 (Python 3.8)
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
