### PR TITLE
[WIP] Hotfix/wrong node placement

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -389,10 +389,14 @@ try:
                 if old_svg_ele is None:
                     with logger.debug("Adding new node to document"):
                         # Place new nodes in the view center and scale them according to user request
-                        from inkex.transforms import Vector2d
 
-                        node_center = Vector2d(tt_node.get_center_position())
-                        view_center = self.svg.get_center_position()
+                        # ToDo: Remove except block as far as new center props are available in official beta releases
+                        try:
+                            node_center = tt_node.bounding_box().center
+                            view_center = self.svg.namedview.center
+                        except AttributeError:
+                            node_center = tt_node.bounding_box().center()
+                            view_center = self.svg.get_center_position()
 
                         tt_node.transform = (Transform(translate=view_center) *    # place at view center
                                              Transform(scale=user_scale_factor) *  # scale

--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -392,14 +392,18 @@ try:
                 # Place new node in document
                 if old_svg_ele is None:
                     with logger.debug("Adding new node to document"):
-                        # Place new nodes in the center of the document and scale them according to user request
-                        doc_width = self.svg.width
-                        doc_height = self.svg.height
-                        x, y, w, h = tt_node.bounding_box()
-                        tt_node.transform = tt_node.transform * \
-                                            Transform(translate=(-x + doc_width / 2 - w / 2,
-                                                                 -y + doc_height / 2 - h / 2)) * \
-                                            Transform(scale=scale_factor)
+                        # Place new nodes in the view center and scale them according to user request
+                        from inkex.transforms import Vector2d
+
+                        node_center = Vector2d(tt_node.get_center_position())
+                        view_center = self.svg.get_center_position()
+
+                        tt_node.transform = (Transform(translate=view_center) *  # place at view center
+                                             Transform(scale=scale_factor) *  # scale
+                                             Transform(translate=-node_center) *  # place node at origin
+                                             tt_node.transform  # use original node transform
+                                             )
+
                         tt_node.set_meta('jacobian_sqrt', str(tt_node.get_jacobian_sqrt()))
 
                         self.svg.get_current_layer().add(tt_node)


### PR DESCRIPTION
New nodes are not properly set in the center of the document.

**Situation before the fix**

![grafik](https://user-images.githubusercontent.com/11866252/71246263-97210e00-2316-11ea-8b76-32efb79aea8a.png)

**Situation after the fix**

![grafik](https://user-images.githubusercontent.com/11866252/71246354-c2a3f880-2316-11ea-9ebd-a8fea69812b0.png)

Two reasons for this behavior:
https://github.com/textext/textext/blob/3f29077b6f440e2937de9c7e04505169e7b9102e/extension/textext/__init__.py#L426

In  fact ``tt_node.bounding_box()`` expands to ``x, w, y, h`` given in pt.

Furthermore
https://github.com/textext/textext/blob/3f29077b6f440e2937de9c7e04505169e7b9102e/extension/textext/__init__.py#L423-L424
returns units in mm (if user has mm for the document unit).

I use new method ``get_center_position()`` provided by Inkscape extension API now. Furthermore, I also removed the hand written ``get_document_width()`` methods (see commit message).

So, finally we now have:
https://github.com/jcwinkler/textext/blob/19ceb80194c2e1432fbd7cfd091d90771052101f/extension/textext/__init__.py#L395-L408


Short checklist:
- [x] Tested with Inkscape version: 1.0beta2 (Python 3.8)
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [x] Tested on Windows, Version: Windows 8.1
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
