### PR TITLE
Fix Ctrl+P shortcut

### DIFF
--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -728,7 +728,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             close_shortcut_value = self._gui_config.get("close_shortcut", self.DEFAULT_CLOSE_SHORTCUT)
             if (close_shortcut_value == 'Escape' and Gdk.keyval_name(event.keyval) == 'Escape') or \
                (close_shortcut_value == 'CtrlQ' and Gdk.keyval_name(event.keyval) == 'q' and
-                Gdk.ModifierType.CONTROL_MASK and event.state):
+                Gdk.ModifierType.CONTROL_MASK & event.state):
                 self._cancel_button.clicked()
                 return True
 

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -715,12 +715,14 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             :param data:
             :return: True, if a shortcut was recognized and handled
             """
-            if Gdk.keyval_name(event.keyval) == 'Return' and Gdk.ModifierType.CONTROL_MASK & event.state:
+
+            ctrl_is_pressed = Gdk.ModifierType.CONTROL_MASK & event.state
+            if Gdk.keyval_name(event.keyval) == 'Return' and ctrl_is_pressed:
                 self._ok_button.clicked()
                 return True
 
             # Show/ update Preview shortcut (CTRL+P)
-            if Gdk.keyval_name(event.keyval) == 'p' and Gdk.ModifierType.CONTROL_MASK & event.state:
+            if Gdk.keyval_name(event.keyval) == 'p' and ctrl_is_pressed:
                 self._preview_button.clicked()
                 return True
 
@@ -728,7 +730,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             close_shortcut_value = self._gui_config.get("close_shortcut", self.DEFAULT_CLOSE_SHORTCUT)
             if (close_shortcut_value == 'Escape' and Gdk.keyval_name(event.keyval) == 'Escape') or \
                (close_shortcut_value == 'CtrlQ' and Gdk.keyval_name(event.keyval) == 'q' and
-                Gdk.ModifierType.CONTROL_MASK & event.state):
+                ctrl_is_pressed):
                 self._cancel_button.clicked()
                 return True
 

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -720,7 +720,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
                 return True
 
             # Show/ update Preview shortcut (CTRL+P)
-            if Gdk.keyval_name(event.keyval) == 'p' and Gdk.ModifierType.CONTROL_MASK and event.state:
+            if Gdk.keyval_name(event.keyval) == 'p' and Gdk.ModifierType.CONTROL_MASK & event.state:
                 self._preview_button.clicked()
                 return True
 


### PR DESCRIPTION
Preview was triggered by bare `P`, not `Ctrl+P`

Short checklist:
- [X] Tested with Inkscape version: [1.1-dev (d3cbf63a92, 2019-12-19)]
- [X] Tested on Linux, Distro: [Ubuntu 18.04]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
