### PR TITLE
Follow .inx schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,13 @@ before_script:
    - export PATH=~/bin:$PATH
    - python test_installation_script.py 2> /dev/null
    - python setup.py
+   - wget https://gitlab.com/inkscape/extensions/raw/master/inkscape.extension.rng
 
 
 script:
   - export PYTHONPATH="`inkscape.beta -x`:$HOME/.config/inkscape/extensions/"
   #- python -m pytest --verbose -s pytests
-
+  - xmllint --noout --relaxng inkscape.extension.rng extension/textext.inx
 after_success:
   # Put a tag if version has changed and (version contains "-dev" on develop) or (version DOES NOT contain "-dev" on master)
   # Reminder: grep -q returns 0 if any match has been found, otherwise nonzero.

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
           - python3-gi-cairo
           - gir1.2-gtk-3.0
           - texlive-latex-base
+          - libxml2-utils
       env:
         - RELEASE_MAKER=true
 

--- a/extension/textext.inx
+++ b/extension/textext.inx
@@ -1,12 +1,14 @@
-<inkscape-extension>
-  <_name>Tex Text</_name>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+  <name>Tex Text</name>
   <id>org.ekips.filter.textext</id>
   <dependency type="executable" location="extensions">textext/__init__.py</dependency>
   <effect implements-custom-gui="true">
     <object-type>all</object-type>
+    <effects-menu>
+        <submenu name="Text"/>
+    </effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">textext/__init__.py</command>
+    <command location="extensions" interpreter="python">textext/__init__.py</command>
   </script>
-  <options silent="true" />
 </inkscape-extension>


### PR DESCRIPTION
This PR adds .inx validation against `inkscape.extension.rng` from master branch of https://gitlab.com/inkscape/extensions

Changes:
`Tex Text` moved to `Text` sub menu 

Short checklist:
- [x] Tested with Inkscape version: [1.1-dev (59c00455b5, 2019-12-21)]
- [x] Tested on Linux, Distro: [Ubuntu 18.04]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
