### PR TITLE
Fix macos extension dir path

### DIFF
--- a/extension/textext/requirements_check.py
+++ b/extension/textext/requirements_check.py
@@ -67,6 +67,10 @@ class MacDefaults(LinuxDefaults):
         path += os.environ["PATH"].split(os.path.pathsep)
         return path
 
+    @property
+    def inkscape_extensions_path(self):
+        return os.path.expanduser("~/Library/Application Support/org.inkscape.Inkscape/config/inkscape/extensions")
+
 
 class WindowsDefaults(Defaults):
 

--- a/extension/textext/requirements_check.py
+++ b/extension/textext/requirements_check.py
@@ -110,7 +110,7 @@ class WindowsDefaults(Defaults):
 
     @property
     def inkscape_extensions_path(self):
-        return os.path.join(os.getenv("APPDATA"), "inkscape\extensions")
+        return os.path.join(os.getenv("APPDATA"), "inkscape", "extensions")
 
     def get_system_path(self):
         return self._tweaked_syspath


### PR DESCRIPTION
Fix path to user `extensions` directory 

Mac path is compatible with inkscape>=1.0beta2

Now paths are computed as follows:
```
Linux     ~/.config/inkscape/extensions
Windows   %APPDATA%\inkscape\extensions
MacOS     ~/Library/Application Support/org.inkscape.Inkscape/config/inkscape/extensions
```

Short checklist:
- [ ] Tested with Inkscape version: [fill in Inkscape version here]
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [x] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
