### PR TITLE
Enabled TkInter under Python 3

### DIFF
--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -41,7 +41,7 @@ from textext.utility import SuppressStream
 
 # Try GTK first
 #   If successful, try GTKSourceView (bonus points!)
-#   If unsuccessful, try TK
+#   If unsuccessful, try TK (first for Python 3, then for Python 2)
 #   When not even TK could be imported, abort with error message
 try:
     import gi
@@ -62,17 +62,24 @@ try:
 
 except (ImportError, TypeError, ValueError) as _:
     try:
-        import Tkinter as Tk
-        import tkMessageBox as TkMsgBoxes
-        import tkFileDialog as TkFileDialogs
+        # TK for Python 3 (if this fails, try Python 2 below)
+        import tkinter as Tk
+        from tkinter import messagebox as TkMsgBoxes
+        from tkinter import filedialog as TkFileDialogs
 
-        TOOLKIT = TK
-    except ImportError:
-        raise RuntimeError("\nNeither PyGTK nor TKinter is available!\nMake sure that at least one of this "
-                           "bindings for the graphical user interface of TexText is installed! Refer to the "
-                           "installation instructions on https://github.com/textext/textext/wiki !\nHint: If you "
-                           "updated Inkscape on Windows you may re-install PyGTK!")
+    except ImportError as _:
+        try:
+            # TK for Python 2
+            import Tkinter as Tk
+            import tkMessageBox as TkMsgBoxes
+            import tkFileDialog as TkFileDialogs
 
+        except ImportError:
+            raise RuntimeError("\nNeither GTK nor TKinter is available!\nMake sure that at least one of these "
+                               "bindings for the graphical user interface of TexText is installed! Refer to the "
+                               "installation instructions on https://textext.github.io/textext/ !")
+
+    TOOLKIT = TK
 
 def set_monospace_font(text_view):
     """

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -33,6 +33,7 @@ TK = "TK"
 TOOLKIT = None
 
 import os
+import sys
 import warnings
 from errors import TexTextCommandFailed, TexTextConversionError
 from textext.utility import SuppressStream
@@ -62,24 +63,21 @@ try:
 
 except (ImportError, TypeError, ValueError) as _:
     try:
-        # TK for Python 3 (if this fails, try Python 2 below)
-        import tkinter as Tk
-        from tkinter import messagebox as TkMsgBoxes
-        from tkinter import filedialog as TkFileDialogs
-
-    except ImportError as _:
-        try:
-            # TK for Python 2
+        if sys.version_info[0] == 3: # TK for Python 3 (if this fails, try Python 2 below)
+            import tkinter as Tk
+            from tkinter import messagebox as TkMsgBoxes
+            from tkinter import filedialog as TkFileDialogs
+        else: # TK for Python 2
             import Tkinter as Tk
             import tkMessageBox as TkMsgBoxes
             import tkFileDialog as TkFileDialogs
+        TOOLKIT = TK
 
-        except ImportError:
-            raise RuntimeError("\nNeither GTK nor TKinter is available!\nMake sure that at least one of these "
-                               "bindings for the graphical user interface of TexText is installed! Refer to the "
-                               "installation instructions on https://textext.github.io/textext/ !")
+    except ImportError:
+        raise RuntimeError("\nNeither GTK nor TKinter is available!\nMake sure that at least one of these "
+                           "bindings for the graphical user interface of TexText is installed! Refer to the "
+                           "installation instructions on https://textext.github.io/textext/ !")
 
-    TOOLKIT = TK
 
 def set_monospace_font(text_view):
     """

--- a/extension/textext/requirements_check.py
+++ b/extension/textext/requirements_check.py
@@ -548,11 +548,17 @@ class TexTextRequirementsChecker(object):
         return RequirementCheckResult(True, ["GTK3 is found"])
 
     def find_tkinter(self):
+        executable = sys.executable
         try:
-            executable = sys.executable
-            defaults.call_command([executable, "-c", "import Tkinter; import tkMessageBox; import tkFileDialog;"])
+            # Python 3
+            defaults.call_command(
+                [executable, "-c", "import tkinter; import tkinter.messagebox; import tkinter.filedialog;"])
         except (KeyError, OSError, subprocess.CalledProcessError):
-            return RequirementCheckResult(False, ["TkInter is not found"])
+            try:
+                # Python 2
+                defaults.call_command([executable, "-c", "import Tkinter; import tkMessageBox; import tkFileDialog;"])
+            except (KeyError, OSError, subprocess.CalledProcessError):
+                return RequirementCheckResult(False, ["TkInter is not found"])
 
         return RequirementCheckResult(True, ["TkInter is found"])
 

--- a/extension/textext/requirements_check.py
+++ b/extension/textext/requirements_check.py
@@ -549,16 +549,15 @@ class TexTextRequirementsChecker(object):
 
     def find_tkinter(self):
         executable = sys.executable
+        if sys.version_info[0] == 3:
+            import_tk_script = "import tkinter; import tkinter.messagebox; import tkinter.filedialog;"
+        else:
+            import_tk_script = "import Tkinter; import tkMessageBox; import tkFileDialog;"
         try:
-            # Python 3
             defaults.call_command(
-                [executable, "-c", "import tkinter; import tkinter.messagebox; import tkinter.filedialog;"])
+                [executable, "-c", import_tk_script])
         except (KeyError, OSError, subprocess.CalledProcessError):
-            try:
-                # Python 2
-                defaults.call_command([executable, "-c", "import Tkinter; import tkMessageBox; import tkFileDialog;"])
-            except (KeyError, OSError, subprocess.CalledProcessError):
-                return RequirementCheckResult(False, ["TkInter is not found"])
+            return RequirementCheckResult(False, ["TkInter is not found"])
 
         return RequirementCheckResult(True, ["TkInter is found"])
 


### PR DESCRIPTION
Related issue(s): #173 

This PR re-enables TkInter support when the extension is run under Python 3. It is good to have this as backup since installation of gtk-bindings is still problematic (see e.g. discussion in #150)

Short checklist:
- [x] Tested with Inkscape version: 1.0 beta 2
- [x] Tested on Linux Kubuntu 18.04 (Python 3.6)
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
