### PR TITLE
Doc: Fixed missing links to TexText 0.11 downloads

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,8 +26,12 @@ author = 'Alexander Blinne, Brian Clarke, Florent Becker, Jan Winkler, Pit Garbe
 
 # The full version, including alpha/beta/rc tags
 release = open("../../extension/textext/VERSION").readline().strip()
-# The short X.Y version
+
+# The short X.Y version (for doc title)
 version = ".".join(release.split(".")[:2])
+
+# Last stable release compatible with Inkscape 0.92
+release_for_inkscape092 = "0.11.0"
 
 
 # -- General configuration ---------------------------------------------------
@@ -187,8 +191,16 @@ extlinks = {
     'issue': ('https://github.com/textext/textext/issues/%s', 'issue #'),
     'bb_issue_num': ('https://bitbucket.org/pv/textext/issues/%s', 'bb#'),
     'bb_issue': ('https://bitbucket.org/pv/textext/issues/%s', 'issue bb#'),
+
+    # Links to current stable release compatible with Inkscape >= 1.0
     'textext_download_zip':    ('https://github.com/textext/textext/releases/download/{release}/TexText-%s-{release}.zip'.format(**locals()), 'v{release}-'.format(**locals())),
     'textext_download_tgz':    ('https://github.com/textext/textext/releases/download/{release}/TexText-%s-{release}.tar.gz'.format(**locals()), 'v{release}-'.format(**locals())),
     'textext_download_exe':    ('https://github.com/textext/textext/releases/download/{release}/TexText-%s-{release}.exe'.format(**locals()), 'v{release}-'.format(**locals())),
     'textext_current_release_page':    ('https://github.com/textext/textext/releases/tag/{release}#%s'.format(**locals()), 'v{release}'.format(**locals())),
+
+    # Links to last stable release compatible with Inkscape 0.92
+    'textext_inkscape092_download_zip': ('https://github.com/textext/textext/releases/download/{release_for_inkscape092}/TexText-%s-{release_for_inkscape092}.zip'.format(**locals()), 'v{release_for_inkscape092}-'.format(**locals())),
+    'textext__inkscape092_download_tgz': ('https://github.com/textext/textext/releases/download/{release_for_inkscape092}/TexText-%s-{release_for_inkscape092}.tar.gz'.format(**locals()), 'v{release_for_inkscape092}-'.format(**locals())),
+    'textext_inkscape092_download_exe': ('https://github.com/textext/textext/releases/download/{release_for_inkscape092}/TexText-%s-{release_for_inkscape092}.exe'.format(**locals()), 'v{release_for_inkscape092}-'.format(**locals())),
+    'textext_inkscape092_current_release_page': ('https://github.com/textext/textext/releases/tag/{release_for_inkscape092}#%s'.format(**locals()),'v{release_for_inkscape092}'.format(**locals())),
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,8 @@ release = open("../../extension/textext/VERSION").readline().strip()
 # The short X.Y version (for doc title)
 version = ".".join(release.split(".")[:2])
 
-# Last stable release compatible with Inkscape 0.92
-release_for_inkscape092 = "0.11.0"
+# Last stable 0.x release (compatible with Inkscape 0.92)
+release_0x = "0.11.0"
 
 
 # -- General configuration ---------------------------------------------------
@@ -199,8 +199,8 @@ extlinks = {
     'textext_current_release_page':    ('https://github.com/textext/textext/releases/tag/{release}#%s'.format(**locals()), 'v{release}'.format(**locals())),
 
     # Links to last stable release compatible with Inkscape 0.92
-    'textext_inkscape092_download_zip': ('https://github.com/textext/textext/releases/download/{release_for_inkscape092}/TexText-%s-{release_for_inkscape092}.zip'.format(**locals()), 'v{release_for_inkscape092}-'.format(**locals())),
-    'textext__inkscape092_download_tgz': ('https://github.com/textext/textext/releases/download/{release_for_inkscape092}/TexText-%s-{release_for_inkscape092}.tar.gz'.format(**locals()), 'v{release_for_inkscape092}-'.format(**locals())),
-    'textext_inkscape092_download_exe': ('https://github.com/textext/textext/releases/download/{release_for_inkscape092}/TexText-%s-{release_for_inkscape092}.exe'.format(**locals()), 'v{release_for_inkscape092}-'.format(**locals())),
-    'textext_inkscape092_current_release_page': ('https://github.com/textext/textext/releases/tag/{release_for_inkscape092}#%s'.format(**locals()),'v{release_for_inkscape092}'.format(**locals())),
+    'textext_0x_download_zip': ('https://github.com/textext/textext/releases/download/{release_0x}/TexText-%s-{release_0x}.zip'.format(**locals()), 'v{release_0x}-'.format(**locals())),
+    'textext_0x_download_tgz': ('https://github.com/textext/textext/releases/download/{release_0x}/TexText-%s-{release_0x}.tar.gz'.format(**locals()), 'v{release_0x}-'.format(**locals())),
+    'textext_0x_download_exe': ('https://github.com/textext/textext/releases/download/{release_0x}/TexText-%s-{release_0x}.exe'.format(**locals()), 'v{release_0x}-'.format(**locals())),
+    'textext_0x_current_release_page': ('https://github.com/textext/textext/releases/tag/{release_0x}#%s'.format(**locals()),'v{release_0x}'.format(**locals())),
 }

--- a/docs/source/install/linux-beta.rst
+++ b/docs/source/install/linux-beta.rst
@@ -76,7 +76,7 @@ executing
 Download and install |TexText|
 ==============================
 
-1. Download the most recent **preview** package from https://github.com/textext/textext/releases
+1. Download the most recent **preview** package from :textext_current_release_page:`GitHub release page <release>`
 2. Extract the package and change into the created directory.
 3. Run :bash:`setup.py` with (**Important!!**) specification of the path to your |Inkscape| executable
    from your terminal:

--- a/docs/source/install/linux.rst
+++ b/docs/source/install/linux.rst
@@ -208,7 +208,7 @@ To install ``xelatex`` on Ubuntu/Debian:
 Install TexText
 ===============
 
-1.  Download the most recent package from :textext_inkscape092_current_release_page:`GitHub release page <release>` (direct links: :textext_inkscape092_download_zip:`.zip <Linux>`, :textext_download_tgz:`.tar.gz <Linux>`)
+1.  Download the most recent package from :textext_0x_current_release_page:`GitHub release page <release>` (direct links: :textext_0x_download_zip:`.zip <Linux>`, :textext_download_tgz:`.tar.gz <Linux>`)
 2.  Extract the package and change to created directory.
 3.  Run :bash:`setup.py` from your terminal:
 

--- a/docs/source/install/linux.rst
+++ b/docs/source/install/linux.rst
@@ -208,7 +208,7 @@ To install ``xelatex`` on Ubuntu/Debian:
 Install TexText
 ===============
 
-1.  Download the most recent package from :textext_current_release_page:`GitHub release page <release>` (direct links: :textext_download_zip:`.zip <Linux>`, :textext_download_tgz:`.tar.gz <Linux>`)
+1.  Download the most recent package from :textext_inkscape092_current_release_page:`GitHub release page <release>` (direct links: :textext_inkscape092_download_zip:`.zip <Linux>`, :textext_download_tgz:`.tar.gz <Linux>`)
 2.  Extract the package and change to created directory.
 3.  Run :bash:`setup.py` from your terminal:
 

--- a/docs/source/install/windows-beta.rst
+++ b/docs/source/install/windows-beta.rst
@@ -57,7 +57,7 @@ Download and install the |Inkscape| app image file
 Download and install |TexText|
 ==============================
 
-1. Download the most recent **preview** package from https://github.com/textext/textext/releases
+1. Download the most recent **preview** package from :textext_current_release_page:`GitHub release page <release>`
 2. Extract the package and change into the created directory.
 3. In a command window run :bash:`setup_win.bat` with (**Important!!**) specification of the
    path to your |Inkscape| executable from your terminal:

--- a/docs/source/install/windows.rst
+++ b/docs/source/install/windows.rst
@@ -143,7 +143,7 @@ You have two options: A setup script or a GUI based installer.
 Setup script (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Download the most recent package from :textext_inkscape092_current_release_page:`GitHub release page <release>` (direct links: :textext_inkscape092_download_zip:`.zip <Windows>`)
+1. Download the most recent package from :textext_0x_current_release_page:`GitHub release page <release>` (direct links: :textext_0x_download_zip:`.zip <Windows>`)
 2. Extract the package and change into the created directory.
 3. Double click on the file :bash:`setup_win.bat`. The script will check if all requirements
    described in :ref:`windows-install-dependencies` are met. If so, it will install the extension
@@ -166,7 +166,7 @@ Installer
 
 If you have trouble with the setup script you can use a GUI based installer:
 
-1. Download the most recent installer from :textext_inkscape092_current_release_page:`GitHub release page <release>` (direct links: :textext_inkscape092_download_exe:`.exe <Windows>`)
+1. Download the most recent installer from :textext_0x_current_release_page:`GitHub release page <release>` (direct links: :textext_0x_download_exe:`.exe <Windows>`)
 2. Use the installer and follow the instructions. It will copy the required files into the user's Inkscape
    configuration directory (usually this is ``%USERPROFILE%\AppData\Roaming\Inkscape``).
 

--- a/docs/source/install/windows.rst
+++ b/docs/source/install/windows.rst
@@ -143,7 +143,7 @@ You have two options: A setup script or a GUI based installer.
 Setup script (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Download the most recent package from :textext_current_release_page:`GitHub release page <release>` (direct links: :textext_download_zip:`.zip <Windows>`)
+1. Download the most recent package from :textext_inkscape092_current_release_page:`GitHub release page <release>` (direct links: :textext_inkscape092_download_zip:`.zip <Windows>`)
 2. Extract the package and change into the created directory.
 3. Double click on the file :bash:`setup_win.bat`. The script will check if all requirements
    described in :ref:`windows-install-dependencies` are met. If so, it will install the extension
@@ -166,7 +166,7 @@ Installer
 
 If you have trouble with the setup script you can use a GUI based installer:
 
-1. Download the most recent installer from :textext_current_release_page:`GitHub release page <release>` (direct links: :textext_download_exe:`.exe <Windows>`)
+1. Download the most recent installer from :textext_inkscape092_current_release_page:`GitHub release page <release>` (direct links: :textext_inkscape092_download_exe:`.exe <Windows>`)
 2. Use the installer and follow the instructions. It will copy the required files into the user's Inkscape
    configuration directory (usually this is ``%USERPROFILE%\AppData\Roaming\Inkscape``).
 


### PR DESCRIPTION
Resolves issue #180

We need to provide both, download links as well as documentation to/ for  TexText 0.11 and TexText 1.0 in the future since it will take some time until Inkscape 1.0 will be the standard on all systems and for all users.