### PR TITLE
Added GUI binding installation instructions for beta releases

### DIFF
--- a/docs/source/install/linux-beta.rst
+++ b/docs/source/install/linux-beta.rst
@@ -73,6 +73,67 @@ executing
     ~/squashfs-root/bin/inkscape &
 
 
+Install GUI library
+===================
+
+Install the Python bindings for the graphical user interface of
+|TexText|. You have two options: ``GTK3`` (recommended) or ``Tkinter``.
+
+At first you need to discover the Python interpreter that is used by your
+Inkscape installation. Enter the following command in a terminal
+
+.. code-block:: bash
+
+        python --version
+
+Keep the returned major version number (Python **2** or Python **3**) in mind
+for the following instructions:
+
+
+.. _linux-beta-install-gtk3:
+
+Install Python GTK3 bindings (recommended)
+------------------------------------------
+
+If your Inkscape installation runs **Python 2** you need the Python 2.x bindings for
+gobject-introspection libraries (``python-gi``), the GTK+ graphical user interface library
+(``gir1.2-gtk-3.0``) and the gir files for the GTK+ syntax highlighting widget
+(``gir1.2-gtksource-3.0``)
+
+.. code-block:: bash
+
+    sudo apt-get install python-gi gir1.2-gtk-3.0 gir1.2-gtksource-3.0
+
+If your Inkscape installation runs **Python 3** you need the Python 3 version of the
+gobject-introspection. The rest remains the same:
+
+.. code-block:: bash
+
+    sudo apt-get install python3-gi gir1.2-gtk-3.0 gir1.2-gtksource-3.0
+
+
+.. _linux-beta-install-tkinter:
+
+Install Tkinter (not recommended)
+---------------------------------
+
+Tkinter is functioning but has a limited interface compared to GTK version, so it's not
+recommended. To use ``Tkinter`` install the  Python ``tk`` package.
+
+If your Inkscape installation runs **Python 2**:
+
+.. code-block:: bash
+
+    sudo apt-get install python-tk
+
+
+If your Inkscape installation runs **Python 3**:
+
+.. code-block:: bash
+
+    sudo apt-get install python3-tk
+
+
 Download and install |TexText|
 ==============================
 

--- a/docs/source/install/windows-beta.rst
+++ b/docs/source/install/windows-beta.rst
@@ -73,14 +73,16 @@ Download and install |TexText|
 
         1. Compared to previous versions of **TexText** for |InkscapeOld| |TexText| does
            not need any conversion utilities like ghostscript, pstoedit or pdfsvg.
+           Furthermore, the required Python bindungs for the GTK-GUI are already included
+           in the windows version of |Inkscape|.
 
-        2. Currently, GTKSourceView is not available in the Windows version of |TexText|, hence
-           syntax highlighting is not enabled.
+        2. Currently, GTKSourceView is not available in the Windows version of |TexText|,
+           hence syntax highlighting is not enabled. An installer will be provided soon.
 
 Now you can launch |Inkscape| by double clicking on ``inkscape.exe`` in ``C:\InkscapeBeta``
 and work with |TexText|
 
-Please report any issues! Thank you!
+**Please report any issues!** Thank you!
 
 
 Switching back to Inkscape |InkscapeOld|


### PR DESCRIPTION
@sizmailov I just extended the installation instructions for TexText development versions by the GTK bindings. What do you think?

Please see https://jcwinkler.github.io/textext/install/linux-beta.html and https://jcwinkler.github.io/textext/install/windows-beta.html

Note that for the final release (i.e. without the AppImage) I provide a completely rewritten version of the help including new screenshots, troubleshooting section etc. I will inform you as soon as it is ready for review.