### PR TITLE
Fix dict_keys object is not subscriptable

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -208,7 +208,7 @@ try:
                 if preferred_tex_cmd in self.requirements_checker.available_tex_to_pdf_converters.keys():
                     current_tex_command = preferred_tex_cmd
                 else:
-                    current_tex_command = self.requirements_checker.available_tex_to_pdf_converters.keys()[0]
+                    current_tex_command = list(self.requirements_checker.available_tex_to_pdf_converters.keys())[0]
 
                 if text:
                     logger.debug("Old node text = %s" % repr(text))


### PR DESCRIPTION
Thank you for your contribution to TexText. Please provide the following information before opening this pull request:

Related issue(s):

Precise description of the changes proposed in the pull request:

Short checklist:
- [x] Tested with Inkscape version: [inkscape 1.0beta2]
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [x] Tested on MacOS, Version:  [macos Mojave 10.14.6]
