### PR TITLE
Hotfix: Unknown option --without-gui

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -543,7 +543,6 @@ try:
             """Convert the PDF file to a SVG file"""
             exec_command([
                 self.checker.inkscape_executable,
-                "--without-gui",
                 "--pdf-poppler",
                 "--pdf-page=1",
                 "--export-type=svg",
@@ -558,7 +557,6 @@ try:
             """Convert the PDF file to a SVG file"""
             exec_command([
                 self.checker.inkscape_executable,
-                "--without-gui",
                 "--pdf-poppler",
                 "--pdf-page=1",
                 "--export-type=png",


### PR DESCRIPTION
Option is deprecated in most recent beta builds of Inkscape 1.0

Related issue(s): #188

Short checklist:
- [x] Tested with Inkscape version: 1.0 beta
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [x] Tested on Windows 10
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
