### PR TITLE
Hotfix: Illegal return of None object instead if empty list

### DIFF
--- a/extension/textext/win_app_paths.py
+++ b/extension/textext/win_app_paths.py
@@ -53,7 +53,7 @@ def get_non_syspath_dirs():
                     _wr.CloseKey(key)
                     # Remove exe name
                     dirname = _os.path.dirname(value)
-                    return [dirname] if _os.path.isdir(dirname) else None
+                    return [dirname] if _os.path.isdir(dirname) else []
                 except WindowsError:
                     _wr.CloseKey(key)
             except WindowsError:


### PR DESCRIPTION
If Inkscape is not found in the defauilt location on Windows
an empty list needs to be returned in order to build a
correct tweaked system path later.

See issue #186

Short checklist:
- [x] Tested with Inkscape version: inkscape-1.0beta2_2020-02-22_6465177-x64
- [x] Tested on Windows 8.1
