### PR TITLE
Fixed: Unknown option --export-file

### DIFF
--- a/extension/textext/__init__.py
+++ b/extension/textext/__init__.py
@@ -548,7 +548,7 @@ try:
                 "--export-type=svg",
                 "--export-text-to-path",
                 "--export-area-drawing",
-                "--export-file", self.tmp('svg'),
+                "--export-filename", self.tmp('svg'),
                 self.tmp('pdf')
             ]
             )
@@ -562,7 +562,7 @@ try:
                 "--export-type=png",
                 "--export-area-drawing",
                 "--export-dpi=300",
-                "--export-file", self.tmp('png'),
+                "--export-filename", self.tmp('png'),
                 self.tmp('pdf')
             ]
             )


### PR DESCRIPTION
Inkscape command line option --export-filename has been changed to --export-filename in Inkscape.

Related issue(s): #188

This change is currently not available in Linux beta builds, only on Windows. Hence, I will keep this PR open until the option is available there.

Short checklist:
- [x] Tested with Inkscape version: 1.0 beta2
- [ ] Tested on Linux -> Test fails on current beta 2 from Dec 3 2019
- [x] Tested on Windows 8.1
- [ ] Tested on MacOS
