### PR TITLE
Fixes 2020 04 15

### DIFF
--- a/textext/base.py
+++ b/textext/base.py
@@ -144,9 +144,9 @@ class TexText(inkex.EffectExtension):
             logging.disable(logging.DEBUG)
 
         logger.debug("TexText initialized")
-        with open(__file__) as fhl:
+        with open(__file__, "rb") as fhl:
             logger.debug("TexText version = %s (md5sum = %s)" %
-                         (repr(__version__), hashlib.md5(fhl.read().encode('utf-8')).hexdigest())
+                         (repr(__version__), hashlib.md5(fhl.read()).hexdigest())
                          )
         logger.debug("platform.system() = %s" % repr(platform.system()))
         logger.debug("platform.release() = %s" % repr(platform.release()))

--- a/textext/base.py
+++ b/textext/base.py
@@ -803,8 +803,13 @@ class TexTextElement(inkex.Group):
                                 key.lower() in ["fill", "stroke", "opacity", "stroke-opacity",
                                                 "fill-opacity"] and value.lower() != "none"}
 
-            # update style of all child nodes
             for it in self.iter():
-                self.style.update(color_style_dict)
-                it.pop("stroke")
-                it.pop("fill")
+                # Update style
+                it.style.update(color_style_dict)
+                # Remove style-duplicating attributes
+                for prop in ("stroke", "fill"):
+                    if prop in style:
+                        it.pop(prop)
+                # Avoid unintentional bolded letters
+                if "stroke-width" not in it.style:
+                    it.style["stroke-width"] = "0"


### PR DESCRIPTION
Related issue(s):
#206

Precise description of the changes proposed in the pull request:
 - Fixes coloring bug
 - Open hash in binary mode to avoid possible unicode errors

Short checklist:
- [X] Tested with Inkscape version: [Inkscape 1.1-dev (e31698fbbb, 2020-03-26)]
- [X] Tested on Linux, Distro: [Ubuntu 19.04]
- [x] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
