### PR TITLE
Fix: use inkscape_extensions_path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -282,7 +282,7 @@ if __name__ == "__main__":
     fh.setFormatter(formatter)
     logger.addHandler(fh)
 
-    settings = Settings()
+    settings = Settings(inkscape_extensions_path=args.inkscape_extensions_path)
 
     checker = TexTextRequirementsChecker(logger, settings)
 

--- a/textext/utility.py
+++ b/textext/utility.py
@@ -145,10 +145,12 @@ class CycleBufferHandler(logging.handlers.BufferingHandler):
 
 
 class Settings(object):
-    def __init__(self, basename="config.json"):
-        from .requirements_check import defaults
+    def __init__(self, basename="config.json", inkscape_extensions_path=None):
+        if inkscape_extensions_path is None:
+            from .requirements_check import defaults
+            inkscape_extensions_path = defaults.inkscape_extensions_path
         self.values = {}
-        self.config_path = os.path.join(defaults.inkscape_extensions_path, "textext", basename)
+        self.config_path = os.path.join(inkscape_extensions_path, "textext", basename)
         try:
             self.load()
         except ValueError as e:


### PR DESCRIPTION
Respect user-provided ext directory path in setup.py

Fixes #211

Short checklist:
- [X] Tested with Inkscape version: [1.1-dev (54cd0712ac, 2020-04-23)]
- [X] Tested on Linux, Distro: [Ubuntu 18.04.1 LTS]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
