### PR TITLE
Account for changed registry keys

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -277,7 +277,9 @@ if __name__ == "__main__":
     ch.setFormatter(formatter)
     logger.addHandler(ch)
 
-    fh = logging.FileHandler("setup.log")
+    # Explicit path spec since on Windows working directory must be the python.exe directory
+    # which is usually read-only for standard users
+    fh = logging.FileHandler(os.path.join(os.path.dirname(__file__), "textextsetup.log"))
     fh.setLevel(ch.level)
     fh.setFormatter(formatter)
     logger.addHandler(fh)

--- a/tests/win_app_paths/test_win_app_path.py
+++ b/tests/win_app_paths/test_win_app_path.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-sys.path.append(os.path.join("../../", "extension", "textext"))
+sys.path.append(os.path.join("../../", "textext"))
 
 import win_app_paths as wap
 

--- a/textext/win_app_paths.py
+++ b/textext/win_app_paths.py
@@ -10,7 +10,8 @@ import subprocess as _sp
 import winreg as _wr
 
 # Windows Registry key under which the installation dir of Inkscape is stored
-INKSCAPE_REG_KEY = r"Software\Microsoft\Windows\CurrentVersion\App Paths\inkscape.exe"
+# Note that "bin" has to be added to that directory
+INKSCAPE_REG_KEY = r"SOFTWARE\Inkscape\Inkscape"
 
 
 def check_cmd_in_syspath(command_name):
@@ -36,12 +37,8 @@ def get_non_syspath_dirs():
     """Returns a list containing the directories of the applications which are not found in the system path"""
     additional_dirs = []
 
-    # Attention! Since the Python interpreter in Inkscape might be 32-bit for both, the 32- and 64-bit Version of
-    # Inkscape, a standard call of OpenKey from within Python only refers to the WOW6432-tree
-    # of the registry. Hence, to check if the 64-bit version of a program is installed on a
-    # 64-bit Windows we have to force to also look in the standard tree. This is done by adding
-    # the Flag KEY_WOW64_64KEY to the read access flag.
-    for access_right in [_wr.KEY_READ, _wr.KEY_READ | _wr.KEY_WOW64_64KEY]:
+    # Try standard registry and the 32bit as well as 64bit mapping of it
+    for access_right in [_wr.KEY_READ, _wr.KEY_READ | _wr.KEY_WOW64_32KEY, _wr.KEY_READ | _wr.KEY_WOW64_64KEY]:
         # Global instalations put their keys in HKLM (HKEY_LOCAL_MACHINE), user installations
         # put their keys in HKCU (HKEY_CURRENT_USER)
         for hkey in [_wr.HKEY_LOCAL_MACHINE, _wr.HKEY_CURRENT_USER]:
@@ -51,8 +48,7 @@ def get_non_syspath_dirs():
                     # Inkscape stores its installation location in a Standard key -> ""
                     value, _ = _wr.QueryValueEx(key, "")
                     _wr.CloseKey(key)
-                    # Remove exe name
-                    dirname = _os.path.dirname(value)
+                    dirname = _os.path.join(value, "bin")
                     return [dirname] if _os.path.isdir(dirname) else []
                 except WindowsError:
                     _wr.CloseKey(key)

--- a/textext/win_app_paths.py
+++ b/textext/win_app_paths.py
@@ -35,7 +35,6 @@ def check_cmd_in_syspath(command_name):
 
 def get_non_syspath_dirs():
     """Returns a list containing the directories of the applications which are not found in the system path"""
-    additional_dirs = []
 
     # Try standard registry and the 32bit as well as 64bit mapping of it
     for access_right in [_wr.KEY_READ, _wr.KEY_READ | _wr.KEY_WOW64_32KEY, _wr.KEY_READ | _wr.KEY_WOW64_64KEY]:
@@ -54,4 +53,11 @@ def get_non_syspath_dirs():
                     _wr.CloseKey(key)
             except WindowsError:
                 pass
+
+    # Last chance: Guess at the two common locations
+    for dirname in ["C:\\Program Files\\Inkscape\\bin", "C:\\Program Files (x86)\\Inkscape\\bin"]:
+        if _os.path.isfile(_os.path.join(dirname, "inkscape.exe")):
+            return [dirname]
+
+    # Give up
     return []


### PR DESCRIPTION
As it turned out Inkscape windows registry keys have been changed in the new 1.0 inkscape installers. Additionally, the registry keys are written into the wrong registry mapping, i.e. Inkscape 64bit is registered as 32bit application on 64bit Windows (I am in contact with Patrick w.r.t this but I am not sure that this will be fixed until Monday). This requires additional search options.

The PR reflects these facts:
- in `setup_win.bat` so the script is able to find the Python interpreter
- in `win_app_paths.py` so we can correctly tweak the path in TexText

Furthermore, it turned out that the way `setup_win.bat` has to invoke `setup.py` via Inkscape's Python interpreter leads to the problem, that the setup log is written into the directory in which python.exe resides. This is read-only for standard users. Hence, as a workaround, the location into which the log is written is explicitely defined (see second last commit)

Short checklist:
- [x] Tested with Inkscape version: 1.0 RC1
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [x] Tested on Windows 10 1909
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]