### PR TITLE
Fixed: LuaLaTeX log not correctly parsed

### DIFF
--- a/textext/base.py
+++ b/textext/base.py
@@ -49,6 +49,7 @@ import os
 import platform
 import sys
 import uuid
+from io import open # ToDo: For open utf8, remove when Python 2 support is skipped
 
 from .requirements_check import defaults, set_logging_levels, TexTextRequirementsChecker
 from .utility import ChangeToTemporaryDirectory, CycleBufferHandler, MyLogger, NestedLoggingGuard, Settings, Cache, \
@@ -570,7 +571,7 @@ class TexToPdfConverter:
             from .texoutparse import LatexLogParser
 
             parser = LatexLogParser()
-            with open(self.tmp('log')) as f:
+            with open(self.tmp('log'), encoding='utf8') as f:
                 parser.process(f)
 
             return parser.errors[0]


### PR DESCRIPTION
Parsing lualatex produced error log fails with the error message

```
'charmap' codec can't decode byte 0x9d in position 1003: character maps to <undefined>
```

This PR fixes the problem on Python2 and Python3

Short checklist:
- [x] Tested with Inkscape version: 1. RC1
- [x] Tested on Linux, Kubuntu 18.04 Python 2.7.17
- [x] Tested on Windows 10 1909 Python 3.8.2
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
