### PR TITLE
Fixed: TexText 0.6 nodes cannot be re-compiled

### DIFF
--- a/textext/base.py
+++ b/textext/base.py
@@ -703,7 +703,7 @@ class TexTextElement(inkex.Group):
 
         # Account for vertical flipping of nodes created via pstoedit in TexText <= 0.11.x
         revert_flip = Transform("scale(1)")
-        if ref_node.get_meta("pdfconverter") == "pstoedit":
+        if ref_node.get_meta("pdfconverter", "pstoedit") == "pstoedit":
             revert_flip = Transform(matrix=((1, 0, 0), (0, -1, 0)))  # vertical reflection
 
         composition = scale_transform * old_transform * revert_flip


### PR DESCRIPTION
Fixes: Nodes created with TexText <= 0.6 cannot be re-compiled.

TexText up to version 0.6 did only offer pstoedit converter backend.
Hence, the corresponding pdfconverter flag is missing in such nodes 
and integration of the compiled svg snippet fails when current TexText 
tries to access this flag. Now it uses pstoedit as default converter if it 
does not find a pdfconverter flag.

Short checklist:
- [x] Tested with Inkscape version: 1.0 RC1
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [x] Tested on Windows, 10 1909 Python 3.8.2
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
