### PR TITLE
Fix typo in linux installation docs

### DIFF
--- a/docs/source/install/linux.rst
+++ b/docs/source/install/linux.rst
@@ -40,7 +40,7 @@ Preparation
    this by invoking at least one of :bash:`pdflatex --version`, :bash:`xelatex --version`, and
    :bash:`lualatex --version` in a terminal.
 
-3. Optional: If you whish to have syntax highlighting and some other :ref:`nice features <usage-gui-config>`
+3. Optional: If you wish to have syntax highlighting and some other :ref:`nice features <usage-gui-config>`
    enabled in the |TexText|-Gui install GTKSourceView:
 
    .. code-block:: bash


### PR DESCRIPTION
Related issue(s): 
None

Precise description of the changes proposed in the pull request:
Fix a typo in the documentation page for installation in linux

Short checklist:
- [ ] Tested with Inkscape version: [fill in Inkscape version here]
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
