### PR TITLE
Fixed: setup_win.bat fails if spaces are in path

### DIFF
--- a/setup_win.bat
+++ b/setup_win.bat
@@ -198,7 +198,7 @@ rem Hence, we change into INKSCAPE_DIR (Attention! Maybe on another drive
 rem as setup_win.bat!) and then call setup.py with its absolute path (%~dp0)
 %INKSCAPE_DIR:~0,2%
 cd %INKSCAPE_DIR%
-set PYTHON_COMMAND=%PYTHON_EXE% %~dp0setup.py %PYTHON_ARGS%
+set PYTHON_COMMAND=%PYTHON_EXE% "%~dp0setup.py" %PYTHON_ARGS%
 echo Trying to run %PYTHON_COMMAND%...
 echo.
 %PYTHON_COMMAND%


### PR DESCRIPTION
Resolves #232

@cedricesc could you check it in your configuration with spaces in path using the attached file? Thanks!

[TexText-Windows-1.1.0.zip](https://github.com/textext/textext/files/4937666/TexText-Windows-1.1.0.zip)

Short checklist:
- [x] Tested with Inkscape version: 1.0
- [x] Tested on Windows, Version: 8.1

