### PR TITLE
Hotfix/temp tex as utf8

### DIFF
--- a/textext/base.py
+++ b/textext/base.py
@@ -60,12 +60,6 @@ with open(os.path.join(os.path.dirname(__file__), "VERSION")) as version_file:
     __version__ = version_file.readline().strip()
 __docformat__ = "restructuredtext en"
 
-if sys.version[0] == '3':
-    unicode = str
-    escape_method = 'unicode_escape'
-else:
-    escape_method = 'string-escape'
-
 EXIT_CODE_OK = 0
 EXIT_CODE_EXPECTED_ERROR = 1
 EXIT_CODE_UNEXPECTED_ERROR = 60
@@ -685,13 +679,13 @@ class TexTextElement(inkex.Group):
 
     def set_meta(self, key, value):
         ns_key = '{{{ns}}}{key}'.format(ns=TEXTEXT_NS, key=key)
-        self.set(ns_key, str(value).encode(escape_method).decode('utf-8'))
+        self.set(ns_key, value)
         assert self.get_meta(key) == value, (self.get_meta(key), value)
 
     def get_meta(self, key, default=None):
         try:
             ns_key = '{{{ns}}}{key}'.format(ns=TEXTEXT_NS, key=key)
-            value = self.get(ns_key).encode('utf-8').decode(escape_method)
+            value = self.get(ns_key)
             if value is None:
                 raise AttributeError('{} has no attribute `{}`'.format(self, key))
             return value

--- a/textext/base.py
+++ b/textext/base.py
@@ -521,7 +521,7 @@ class TexToPdfConverter:
             # Convert TeX to PDF
 
             # Write tex
-            with open(self.tmp('tex'), 'w') as f_tex:
+            with open(self.tmp('tex'), mode='w', encoding='utf-8') as f_tex:
                 f_tex.write(texwrapper)
 
             # Exec tex_command: tex -> pdf


### PR DESCRIPTION
Related issue: #241

Since on Windows the default encoding for writing files is not UTF-8 this encoding is enforced now for writing the temporary tex file. This enables users to utilize full unicode support if they include the corresponding packages (first commit).

When the extension is run under Python 2.7 on older Linux systems the setting of the meta data fails if the text contains unicode chars ('str(value)' fails). Luckily the setting of the meta data in the base class already handles the fact that `str` is unicode on Python 3 but not on Python 2. Hence, the encoding-decoding routines in TexText have been removed (second commit).

Short checklist:
- [x] Tested with Inkscape version: 1.0
- [x] Tested on Kubuntu 18.04 with Python 2.7.14 and Python 3.6.2
- [x] Tested on Windows, 8.1 with Python 3.8.2
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
