### PR TITLE
Add "stroke-width=0pt" to SVG elements with "stroke=none"

### DIFF
--- a/textext/base.py
+++ b/textext/base.py
@@ -839,5 +839,5 @@ class TexTextElement(inkex.Group):
         so for full colorization of a node you need to set the fill as well as the stroke color!).
         """
         for it in self.iter():
-            if "stroke" in it.style and it.style["stroke"].lower() == "none":
+            if it.style.get("stroke", "").lower() == "none":
                 it.style["stroke-width"] = "0"

--- a/textext/base.py
+++ b/textext/base.py
@@ -395,6 +395,8 @@ class TexText(inkex.EffectExtension):
 
                     tt_node.set_meta('jacobian_sqrt', str(tt_node.get_jacobian_sqrt()))
 
+                    tt_node.set_none_strokes_to_0pt()
+
                     self.svg.get_current_layer().add(tt_node)
             else:
                 with logger.debug("Replacing node in document"):
@@ -826,3 +828,16 @@ class TexTextElement(inkex.Group):
                 # Avoid unintentional bolded letters
                 if "stroke-width" not in it.style:
                     it.style["stroke-width"] = "0"
+
+    def set_none_strokes_to_0pt(self):
+        """
+        Iterates over all elements of the node. For each element which has the style attribute
+        "stroke" set to "none" a style attribute "stroke-width" with value "0" is added. This
+        ensures that when colorizing the node later in inkscape by setting the node and
+        stroke colors letters do not become bold (letters have "stroke" set to "none" but e.g.
+        horizontal lines in fraction bars and square roots are only affected by stroke colors
+        so for full colorization of a node you need to set the fill as well as the stroke color!).
+        """
+        for it in self.iter():
+            if "stroke" in it.style and it.style["stroke"].lower() == "none":
+                it.style["stroke-width"] = "0"


### PR DESCRIPTION
For each element which has the style attribute "stroke"
set to "none" a style attribute "stroke-width" with
value "0" is added. This ensures that when colorizing
the node later in inkscape by setting the node and
stroke colors letters do not become bold (letters have
"stroke" set to "none" but e.g. horizontal lines in
fraction bars and square roots are only affected by
stroke colors so for full colorization of a node you
need to set the fill as well as the stroke color!).

**Colorized node (fill + stroke color) before this commit:**
![grafik](https://user-images.githubusercontent.com/11866252/90875722-e6d24080-e3a1-11ea-9fc1-a8c1d6ec9de3.png)


**Colorized node (fill + stroke color) after this commit:**
![grafik](https://user-images.githubusercontent.com/11866252/90875575-a83c8600-e3a1-11ea-83a9-4b3d4570a898.png)

What do you think @sizmailov?

Short checklist:
- [x] Tested with Inkscape version: 1.0
- [x] Tested on Linux Kubuntu 18.04 Python 2.7 and 3.6
- [x] Tested on Windows, 8.1
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
