### PR TITLE
Fixed: Fileinfo not shown in log file

### DIFF
--- a/textext/utility.py
+++ b/textext/utility.py
@@ -60,15 +60,17 @@ class MyLogger(logging.Logger):
         for _ in range(2 + n_frames_upper):  # <-- correct frame
             if f is not None:
                 f = f.f_back
-        rv = "(unknown file)", 0, "(unknown function)"
+        rv = "(unknown file)", 0, "(unknown function)", None
         while hasattr(f, "f_code"):
             co = f.f_code
             filename = os.path.normcase(co.co_filename)
             if filename == logging._srcfile:
                 f = f.f_back
                 continue
-            rv = (co.co_filename, f.f_lineno, co.co_name)
+            rv = (co.co_filename, f.f_lineno, co.co_name, None)
             break
+        if sys.version_info[0] == 2:  # ToDo: Remove when Python 2 support is deprecated
+            rv = rv[0:3]
         return rv
 
 


### PR DESCRIPTION
**Before fix:**
```bash
[2020-08-24 00:28:10,253][DEBUG   ]: TexText version = '1.1.0' (md5sum = b8e2f0897e7bf7607690ffcf8c569772)          //  (unknown file):0    
[2020-08-24 00:28:10,253][DEBUG   ]: platform.system() = 'Windows'          //  (unknown file):0    
[2020-08-24 00:28:10,253][DEBUG   ]: platform.release() = '10'          //  (unknown file):0    
[2020-08-24 00:28:10,253][DEBUG   ]: platform.version() = '10.0.18362'          //  (unknown file):0    
[2020-08-24 00:28:10,253][DEBUG   ]: platform.machine() = 'AMD64'          //  (unknown file):0  
```
**After fix:**

``` bash
[2020-08-24 00:05:47,744][DEBUG   ]: TexText version = '1.1.0' (md5sum = b8e2f0897e7bf7607690ffcf8c569772)          //  base.py:145  
[2020-08-24 00:05:47,744][DEBUG   ]: platform.system() = 'Windows'          //  base.py:148  
[2020-08-24 00:05:47,744][DEBUG   ]: platform.release() = '10'          //  base.py:149  
[2020-08-24 00:05:47,744][DEBUG   ]: platform.version() = '10.0.18362'          //  base.py:150  
[2020-08-24 00:05:47,744][DEBUG   ]: platform.machine() = 'AMD64'          //  base.py:152  
```

In Python 2 Logger.findCaller returns a 3-tupel, however in Python 3 Logger.findCaller is expected to return a 4-tupel.

https://docs.python.org/2.7/library/logging.html#logging.Logger.findCaller

https://docs.python.org/3.8/library/logging.html#logging.Logger.findCaller

Short checklist:
- [x] Tested with Inkscape version: 1.0
- [x] Tested on Linux, Distro: [fill in distribution name here]
- [x] Tested on Windows 10 2004
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
