### PR TITLE
Workaround: Missing harfbuzz typelib in Inkscape 1.0.1

### DIFF
--- a/textext/asktext.py
+++ b/textext/asktext.py
@@ -45,6 +45,14 @@ from textext.utility import SuppressStream
 #   If unsuccessful, try TK (first for Python 3, then for Python 2)
 #   When not even TK could be imported, abort with error message
 try:
+    # Hotfix for Inkscape 1.0.1 on Windows: HarfBuzz-0.0.typelib is missing
+    # in the Inkscape installation Python subsystem, hence we ship
+    # it manually and set the search path accordingly here
+    # ToDo: Remove this hotfix when Inkscape 1.0.2 is released and mark
+    #       Inkscape 1.0.1 as incompatible with TexText
+    if os.name == 'nt':
+        os.environ['GI_TYPELIB_PATH'] = os.path.dirname(os.path.abspath(__file__))
+
     import gi
 
     gi.require_version("Gtk", "3.0")


### PR DESCRIPTION
Relates to #253

Inkscape 1.0.1 on Windows is shipped with a Python subsystem which differs from the one shipped with Inkscape 1.0.0. As a consequence, due to changes in the gobject introspection system, the harfbuzz.typelib is not packaged in Inkscape 1.0.1 on Windows. This workaround adds the texttext extension directory to the the search path for the typelibs. Windows packages of TexText are now manually equipped by me with the missing harfbuzz typelib.

I know that we do again "fixing" errors which are in fact Inkscape errors. But I do not want to wait months until an Inkscape fix is released and TexText users are forced to use the antique TK interface.

I will remove this fix when a fixed Inkscape version is released (most probably 1.0.2). See also the correpsonding merge request in Inkscape repo: https://gitlab.com/inkscape/inkscape/-/merge_requests/2338  (Unfortunately no reaction so far)

Short checklist:
- [x] Tested with Inkscape version 1.0.0 and 1.0.1
- [x] Tested on Windows

