### PR TITLE
Don't copy temporary files on install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import stat
 import tempfile
+import fnmatch
 
 from textext.requirements_check import \
     set_logging_levels, \
@@ -114,6 +115,21 @@ class CopyFileAlreadyExistsError(RuntimeError):
     pass
 
 
+_ignore_patterns = [
+    '__pycache__',
+    '*.pyc',
+    '*.log',
+]
+
+
+def is_ignored(filename):
+    for pattern in _ignore_patterns:
+        if fnmatch.fnmatch(filename, pattern):
+            return True
+
+    return False
+
+
 def copy_extension_files(src, dst, if_already_exists="raise"):
     """
     src: glob expresion to copy from
@@ -131,6 +147,10 @@ def copy_extension_files(src, dst, if_already_exists="raise"):
     for file in glob.glob(src):
         basename = os.path.basename(file)
         destination = os.path.join(dst, basename)
+
+        if is_ignored(basename):
+            continue
+
         if os.path.exists(destination):
             if if_already_exists == "raise":
                 logger.critical("Can't copy `%s`: `%s` already exists" % (file, destination))


### PR DESCRIPTION
Python creates a bunch of temporary files which are copied on installation. Might be useful for devs only.

Short checklist:
- [X] Tested with Inkscape version: [fInkscape 1.1-dev (ad8effaa6e, 2020-11-17)]
- [X] Tested on Linux, Distro: [Ubuntu 20.04.1 LTS]
- [x] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
