### PR TITLE
Update documentation reflecting Debian packaging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,13 +30,11 @@ Download
 
 Download of the most recent version (and older ones): https://github.com/textext/textext/releases
 
-
 Documentation
 -------------
 
-Documentation hosted at https://textext.github.io/textext
-It contains `installation <installation-toc_>`_ and `usage <usage-toc_>`_ instructions
-
+Documentation hosted at https://textext.github.io/textext.
+It contains `installation <installation-toc_>`_ and `usage <usage-toc_>`_ instructions.
 
 History
 -------

--- a/docs/source/install/linux.rst
+++ b/docs/source/install/linux.rst
@@ -77,12 +77,22 @@ Download and install |TexText|
    Compared to previous versions |TexText| does not need any conversion utilities like
    ghostscript, pstoedit or pdfsvg.
 
-1. Download the most recent package from :textext_current_release_page:`GitHub release page <release>`
+1. Check if there are native packages for your distribution.  For instance, on Debian
+   and derivatives (Bullseye and later), TexText can be installed directly from the
+   official repositories:
+
+   .. code-block:: bash
+
+        sudo apt install inkscape-textext
+
+   If not, continue to follow the manual installation instructions.
+
+2. Download the most recent package from :textext_current_release_page:`GitHub release page <release>`
    (direct links: :textext_download_zip:`.zip <Linux>`, :textext_download_tgz:`.tar.gz <Linux>`)
 
-2. Extract the package and change into the created directory.
+3. Extract the package and change into the created directory.
 
-3. If you installed Inkscape via a package manager run :bash:`setup.py` from your terminal:
+4. If you installed Inkscape via a package manager run :bash:`setup.py` from your terminal:
 
    .. code-block:: bash
 


### PR DESCRIPTION
Skipping the checklist, since it isn't really relevant.  This merge simply updates the documentation reflecting the presence of the inkscape-textext package in both [Debian](https://packages.debian.org/source/testing/inkscape-textext) and [Ubuntu](https://launchpad.net/ubuntu/+source/inkscape-textext).

This doesn't update the readme, maybe that should be updated as well?