### PR TITLE
Improvement of documentation (setup script, Debian packages)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,8 +21,8 @@
 # -- Project information -----------------------------------------------------
 
 project = 'TexText'
-copyright = '2020, Alexander Blinne, Brian Clarke, Florent Becker, Jan Winkler, Pit Garbe, Pauli Virtanen, Robert Szalai, Rafal Kolanski, Sergei Izmailov, Toru Araki, @veltsov, Vladislav Gavryusev'
-author = 'Alexander Blinne, Brian Clarke, Florent Becker, Jan Winkler, Pit Garbe, Pauli Virtanen, Robert Szalai, Rafal Kolanski, Sergei Izmailov, Toru Araki, @veltsov, Vladislav Gavryusev'
+copyright = '2021, TexText developers'
+author = 'Alexander Blinne, Antonio Russo, Brian Clarke, Florent Becker, Jan Winkler, Pit Garbe, Pauli Virtanen, Robert Szalai, Rafal Kolanski, Sergei Izmailov, Toru Araki, @veltsov, Vladislav Gavryusev'
 
 # The full version, including alpha/beta/rc tags
 release = open("../../textext/VERSION").readline().strip()

--- a/docs/source/install/linux.rst
+++ b/docs/source/install/linux.rst
@@ -77,22 +77,14 @@ Download and install |TexText|
    Compared to previous versions |TexText| does not need any conversion utilities like
    ghostscript, pstoedit or pdfsvg.
 
-1. Check if there are native packages for your distribution.  For instance, on Debian
-   and derivatives (Bullseye and later), TexText can be installed directly from the
-   official repositories:
-
-   .. code-block:: bash
-
-        sudo apt install inkscape-textext
-
-   If not, continue to follow the manual installation instructions.
-
-2. Download the most recent package from :textext_current_release_page:`GitHub release page <release>`
+1. If you are on Debian Bullseye or later refer to section :ref:`linux-textext-packages`.
+   Otherwise download the most recent package from the
+   :textext_current_release_page:`GitHub release page <release>`
    (direct links: :textext_download_zip:`.zip <Linux>`, :textext_download_tgz:`.tar.gz <Linux>`)
 
-3. Extract the package and change into the created directory.
+2. Extract the package and change into the created directory.
 
-4. If you installed Inkscape via a package manager run :bash:`setup.py` from your terminal:
+3. If you installed Inkscape via a package manager run :bash:`setup.py` from your terminal:
 
    .. code-block:: bash
 
@@ -194,3 +186,17 @@ If your Inkscape installation runs **Python 3**:
 .. code-block:: bash
 
     sudo apt-get install python3-tk
+
+
+.. _linux-textext-packages:
+
+Installation on Debian Bullseye and later
+=========================================
+
+TexText can be installed directly from the official repositories:
+
+   .. code-block:: bash
+
+        sudo apt install inkscape-textext
+
+Then consult the :ref:`usage instructions <gui>`.

--- a/docs/source/install/linux.rst
+++ b/docs/source/install/linux.rst
@@ -121,8 +121,11 @@ Download and install |TexText|
 
             python setup.py --skip-requirements-check --inkscape-executable /home/path/to/your/appimage/Inkscape-4035a4f-x86_64.AppImage
 
-You are done. Now you can consult the :ref:`usage instructions <gui>`. In case of problems consult
-:ref:`troubleshooting`.
+.. note::
+
+    In case of installation problems refer to the :ref:`trouble_installation` in the :ref:`troubleshooting` section!
+
+You are done. Now you can consult the :ref:`usage instructions <gui>`.
 
 .. _linux-install-gui:
 

--- a/docs/source/install/macos.rst
+++ b/docs/source/install/macos.rst
@@ -66,6 +66,9 @@ Download and install |TexText|
    The script  will copy the required files into the user's Inkscape
    configuration directory (usually this is ``~/.config/inkscape/extensions``)
 
-You are done. Now you can consult the :ref:`usage instructions <gui>`. In case of problems consult
-:ref:`troubleshooting`.
+.. note::
 
+    In case of installation problems refer to the :ref:`trouble_installation` in the :ref:`troubleshooting` section!
+
+
+You are done. Now you can consult the :ref:`usage instructions <gui>`.

--- a/docs/source/install/windows.rst
+++ b/docs/source/install/windows.rst
@@ -82,17 +82,15 @@ Setup script (recommended)
 
 .. note::
 
-    If you would like to skip the requirement checks during installation call the script
-    from the command line as follows:
+    In case of installation problems refer to the :ref:`trouble_installation` in the :ref:`troubleshooting` section!
 
-    .. code-block:: bash
 
-        setup_win.bat --skip-requirements-check
+
 
 Installer
 ---------
 
-If you have trouble with the setup script you can use a GUI based installer:
+You can also use a GUI based installer:
 
 1. Download the most recent installer from :textext_current_release_page:`GitHub release page <release>` (direct links: :textext_download_exe:`.exe <Windows>`)
 2. Use the installer and follow the instructions. It will copy the required files into the user's Inkscape
@@ -105,9 +103,7 @@ If you have trouble with the setup script you can use a GUI based installer:
     :ref:`above <windows-install-preparation>` correctly.
 
 
-You are done. Now you can consult the :ref:`usage instructions <gui>`. In case of problems consult
-:ref:`troubleshooting`.
-
+You are done. Now you can consult the :ref:`usage instructions <gui>`.
 
 .. _windows-install-library:
 .. _windows-install-gtk3:

--- a/docs/source/usage/troubleshooting.rst
+++ b/docs/source/usage/troubleshooting.rst
@@ -1,4 +1,6 @@
 .. |TexText| replace:: **TexText**
+.. |Lin| replace:: **Linux/ MacOS**
+.. |Win| replace:: **Windows**
 
 .. role:: bash(code)
    :language: bash
@@ -13,6 +15,105 @@
 Troubleshooting
 ---------------
 
+.. contents:: :local:
+    :depth: 1
+
+.. _trouble_installation:
+
+Installation problems
+=====================
+
+The setup script offers several command line options which may help to fix the
+most common problems during the installation process. For this purpose open a
+Terminal or Windows Command Prompt and enter one of the commands listed below:
+
+- Inkscape is not found by the installation script -> specify the path to the executable:
+
+    - |Lin|
+
+    .. code-block:: bash
+
+        python setup.py --inkscape-executable /path/to/my\ Inkscape/inkscape
+
+    - |Win| (note the double quotes!)
+
+    .. code-block:: bash
+
+        setup_win.bat --inkscape-executable "C:\My\Installation Location\bin\inkscape.exe"
+
+- Inkscape does not find |TexText| although it has been installed -> notify the setup script
+  about a user-defined (non-standard) installation location for the Inkscape extensions
+
+    - |Lin|
+
+    .. code-block:: bash
+
+        python setup.py --inkscape-extensions-path /path/to/user\ defined/location
+
+    - |Win| (note the double quotes!)
+
+    .. code-block:: bash
+
+        setup_win.bat --inkscape-extensions-path "C:\Users\My extension location"
+
+- The LaTeX engines are not found in the system path by the setup script -> specify the
+  path to the executables:
+
+    - |Lin|
+
+    .. code-block:: bash
+
+        python setup.py --pdflatex-executable /path/to/my\ latex/pdflatex
+
+    also available: ``--lualatex-executable`` and ``--xelatex-executable`` for the LuaLaTex and
+    XeLaTeX executables, respectively.
+
+    - |Win| (note the double quotes!)
+
+    .. code-block:: bash
+
+        setup_win.bat --pdflatex-executable "C:\Program Files\My Latex\pdflatex.exe"
+
+    also available: ``--lualatex-executable`` and ``--xelatex-executable`` for the LuaLaTex and
+    XeLaTeX executables, respectively.
+
+- Completely skip all requirement checks during installation and just copy the |TexText| files into
+  the extension directory:
+
+    - |Lin|
+
+    .. code-block:: bash
+
+        python setup.py --skip-requirements-check
+
+    - |Win|
+
+    .. code-block:: bash
+
+        setup_win.bat --skip-requirements-check
+
+- General help:
+
+    - |Lin|
+
+    .. code-block:: bash
+
+        python setup.py --help
+
+    - |Win|
+
+    .. code-block:: bash
+
+        setup_win.bat --help
+
+.. important::
+
+    Do not hesitate to file a report if you cannot solve your installation problems:
+    `github <https://github.com/textext/textext/issues/new/choose>`_
+
+Problems running |TexText|
+==========================
+
 There are three main reasons why something may went wrong:
 
 1. Your LaTeX code contains invalid commands or syntax errors.
@@ -20,7 +121,7 @@ There are three main reasons why something may went wrong:
 2. The installed toolchain for the conversion of your code to a valid SVG element
    is for some reason broken.
 
-3. |TexText| contains a bug and you are the person who discovers it!
+3. |TexText| contains a bug and you are the person who discovered it!
 
 |TexText| helps you to resolve such issues by offering detailed error and logging information.
 

--- a/docs/source/usage/troubleshooting.rst
+++ b/docs/source/usage/troubleshooting.rst
@@ -33,7 +33,7 @@ Terminal or Windows Command Prompt and enter one of the commands listed below:
 
     .. code-block:: bash
 
-        python setup.py --inkscape-executable /path/to/my\ Inkscape/inkscape
+        python setup.py --inkscape-executable '/path/to/my Inkscape/inkscape'
 
     - |Win| (note the double quotes!)
 
@@ -48,7 +48,7 @@ Terminal or Windows Command Prompt and enter one of the commands listed below:
 
     .. code-block:: bash
 
-        python setup.py --inkscape-extensions-path /path/to/user\ defined/location
+        python setup.py --inkscape-extensions-path '/path/to/user defined/location'
 
     - |Win| (note the double quotes!)
 
@@ -63,7 +63,7 @@ Terminal or Windows Command Prompt and enter one of the commands listed below:
 
     .. code-block:: bash
 
-        python setup.py --pdflatex-executable /path/to/my\ latex/pdflatex
+        python setup.py --pdflatex-executable '/path/to/my latex/pdflatex'
 
     also available: ``--lualatex-executable`` and ``--xelatex-executable`` for the LuaLaTex and
     XeLaTeX executables, respectively.

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -94,22 +94,22 @@ echo use TexText are not met. In the last case the script lists the steps to
 echo be done for an successfull installation.
 echo.
 echo setup_win --inkscape-executable "C:\Path\to\Inkscape installation\inkscape.exe"
-echo Installs TexText with the default options assuming that Inkscape is located
-echo in the directory "C:\Path\to\Inkscape installation\". This syntax is only
-echo required if you have not installed Inkscape via an installer but from a
-echo zip package.
+echo Installs TexText with the default options assuming that the inkscape executable
+echo can be called via "C:\Path\to\Inkscape installation\inkscape.exe". This syntax
+echo is only required if you have not installed Inkscape via an installer but from a
+echo zip package. Note the double quotes sourrounding the path.
 echo.
 echo setup_win --option1 "value 1" --option2 "value 2"
 echo Installs TexText using the Python distribution shipped with
 echo Inkscape and directly passes the parameter string
 echo --option1 "value 1" --option2 "value 2" to setup.py. You can pass any
 echo parameters understood by setup.py. Call setup_win --help to list all available
-echo options.
+echo options. Note the double quotes sourrounding the values.
 echo.
 echo You can combine the last two calling syntaxes, of course.
 echo.
 echo Example:
-echo setup_win.bat --inkscape-executable "C:\Program Files\Inkscape" 
+echo setup_win.bat --inkscape-executable "C:\Program Files\Inkscape\inkscape.exe" 
 echo --pdflatex-executable "C:\Program Files\MiKTeX 2.9\miktex\bin\x64\pdflatex.exe"
 goto FINAL
 
@@ -219,9 +219,9 @@ goto FINAL
 :INKSCAPE_NOT_FOUND
 echo Inkscape neither found in the registry, nor in the most common
 echo installation directories nor in the system path!
-echo Specifiy an explicit directory via the --inkscape-executable option 
-echo to look for if you installed Inkscape from a zip package. E.g.:
-echo setup_win --inkscape-executable "C:\Path\to\Inkscape installation\"
+echo Specifiy an explicit location of inkscape.exe via the --inkscape-executable
+echo option if you installed Inkscape from a zip package. E.g.:
+echo setup_win --inkscape-executable "C:\Path\to\Inkscape installation\inkscape.exe"
 echo.
 echo Cannot continue!
 echo.


### PR DESCRIPTION
This PR addresses three improvements in the documentation:

- The messages of the Windows setup script `setup_win.bat` are more precise now and do clearly state and illustrate what is meant. This addresses issue #280

- The command line options of the setup script are explained in detail and are associated with the corresponding setup scenarios/ problems. This addresses issue #276 (see https://github.com/textext/textext/issues/276#issuecomment-761868727). 

  Here is a rendered version: [Setup-Script options](https://jcwinkler.github.io/textext/usage/troubleshooting.html) referenced in [Linux](https://jcwinkler.github.io/textext/install/linux.html#linux-install-textext), [Windows](https://jcwinkler.github.io/textext/install/windows.html#windows-install-textext), and [Mac](https://jcwinkler.github.io/textext/install/macos.html#macos-install-textext) installation instructions.

- The possibility to install TexText packages via apt-get in Debian Bullseye has been moved into a separate section (I prefer this way as long as this is not available to a broader set of distributions. Later we can instruct sth. like "First try your package manager, if this fails go to the manual installation")

  Here is a [rendered version](https://jcwinkler.github.io/textext/install/linux.html#linux-install-textext)