### PR TITLE
Windows: Detect path to Inkscape when Inkscape has been installed via MSI installer

### DIFF
--- a/setup_win.bat
+++ b/setup_win.bat
@@ -117,14 +117,14 @@ goto FINAL
 :DETECT_INKSCAPE_LOCATION
 echo Trying to find Inkscape in Windows Registry...
 
+rem Checking NSIS-Installer registry information
 rem Inkscape installation path is usually found in the registry
-rem "SOFTWARE\Inkscape\Inkscape"
-rem under HKLM (Local Machine -> machine wide installation) or
-rem HKCU (Current User -> user installation)
+rem "SOFTWARE\Inkscape\Inkscape" under HKLM (Local Machine -> 
+rem machine wide installation) or rem HKCU (Current User -> 
+rem user installation) if installed via NSIS exe installer.
 rem We also have to keep in mind that the values might be in the 32bit or 64bit 
 rem version of the registry (i.e., under SOFTWARE\WOW6432Node\Inkscape\Inkscape
 rem or SOFTWARE\Inkscape\Inkscape)
-rem This holds if Inkscape has been installed via via NSIS, not via MSI
 for %%R in (HKLM HKCU) do (
 	for %%T in (32 64) do (
 		rem Output of REG QUERY "KeyName" /ve is (first line is a blank line):
@@ -136,7 +136,7 @@ for %%R in (HKLM HKCU) do (
 		rem so we skip the first two lines (skip=2) and then we take the second token
 		rem and the reamining output (tokens=2*), so %%A is REG_SZ and %%B is the path
 		rem even if it contains spaces (tokens are delimited by spaces)
-		echo    Trying registry root %%R [%%T]...
+		echo    Trying SOFTWARE\Inkscape\Inkscape in registry root %%R [%%T]...
 		for /f "usebackq skip=2 tokens=2*" %%A in (`REG QUERY "%%R\SOFTWARE\Inkscape\Inkscape" /ve /reg:%%T 2^>nul`) do (
 			if exist %%B (
 				set INKSCAPE_DIR=%%B
@@ -156,6 +156,33 @@ for %%R in (HKLM HKCU) do (
 		)
 	)
 )
+
+
+rem Checking MSI-Installer registry information
+rem Inkscape installation path is usually found in the registry
+rem under key "Path" in 
+rem SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\inkscape.exe
+rem if installed via msi installer
+for %%T in (32 64) do (
+	echo    Trying SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\inkscape.exe in registry root HKLM [%%T]...
+	for /f "usebackq skip=2 tokens=2*" %%A in (`REG QUERY "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\inkscape.exe" /v Path /reg:%%T 2^>nul`) do (
+		if exist %%B (
+			set INKSCAPE_DIR=%%B
+		)
+	)
+	if defined INKSCAPE_DIR (
+		echo    Inkscape considered to be installed in !INKSCAPE_DIR!
+		echo    Setting executable path to !INKSCAPE_DIR!
+		if exist "!INKSCAPE_DIR!\!INKSCAPE_EXENAME!" (
+			echo !INKSCAPE_DIR!\!INKSCAPE_EXENAME! found
+			echo.
+			goto    INKSCAPE_FOUND
+		) else (
+			echo    !INKSCAPE_DIR!\!INKSCAPE_EXENAME! not found
+		)
+	)
+)
+
 
 rem If we did non succeed in the registry lets have a look 
 rem at the most common install locations


### PR DESCRIPTION
Inkscape MSI installer uses different registry keys compared to NSIS installer. Hence, if Inkscape has been installed in a non-standard directory on Windows, setup fails. This is fixed now.

See Inkscape [commit](https://gitlab.com/jcwinkler/inkscape/-/commit/33de3f795262a7460684e4079ee25b2f34dabb18) and [merge](https://gitlab.com/inkscape/inkscape/-/merge_requests/2863) and [discussion](https://gitlab.com/inkscape/inkscape/-/issues/2255).

Short checklist:
- [x] Tested with Inkscape version: 1.1
- [x] Tested on Windows, Version: 8.1
