### PR TITLE
Enable/ fully support system wide installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,7 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--inkscape-extensions-path",
-        default=defaults.inkscape_extensions_path,
+        default=defaults.inkscape_user_extensions_path,
         type=str,
         help="Path to inkscape extensions directory"
     )
@@ -294,8 +294,7 @@ if __name__ == "__main__":
 
     files_to_keep = {  # old_name : new_name
         "default_packages.tex": "textext/default_packages.tex",  # old layout
-        "textext/default_packages.tex": "textext/default_packages.tex",  # new layout
-        "textext/config.json": "textext/config.json"  # new layout
+        "textext/default_packages.tex": "textext/default_packages.tex"
     }
 
     args = parser.parse_args()
@@ -322,7 +321,7 @@ if __name__ == "__main__":
     fh.setFormatter(formatter)
     logger.addHandler(fh)
 
-    settings = Settings(directory=os.path.join(args.inkscape_extensions_path, "textext"))
+    settings = Settings(directory=defaults.textext_config_path)
 
     checker = TexTextRequirementsChecker(logger, settings)
 

--- a/setup.py
+++ b/setup.py
@@ -286,6 +286,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--all-users",
+        default=None,
+        action='store_true',
+        help="Install globally for all users"
+    )
+
+    parser.add_argument(
         "--color",
         default=defaults.console_colors,
         choices=("always", "never"),
@@ -298,7 +305,6 @@ if __name__ == "__main__":
     }
 
     args = parser.parse_args()
-    args.inkscape_extensions_path = os.path.expanduser(args.inkscape_extensions_path)
 
     if args.color == "always":
         LoggingColors.enable_colors = True
@@ -355,6 +361,50 @@ if __name__ == "__main__":
             exit(EXIT_REQUIREMENT_CHECK_FAILED)
 
     if not args.skip_extension_install:
+        if args.all_users:
+            # Determine path of global installation if requested
+            logger.info("Global installation requested, trying to find system extension path...")
+
+            if args.inkscape_executable is not None:
+                logger.info("Inkscape executable given as `%s`" % args.inkscape_executable)
+                inkscape_executable = args.inkscape_executable
+            else:
+                # This is quite complicated and in fact only necessary on Windows.
+                # In Windows inkscape.exe is not in the system path so we use the
+                # tweaked path return by default.get_system_path() and iterate
+                # over its elements
+                # ToDo: Make this smarter and more intuitive!
+                logger.info("Trying to find Inkscape executable automatically...")
+                inkscape_executable = None
+                for inkscape_exe_name in defaults.executable_names["inkscape"]:
+                    for path in defaults.get_system_path():
+                        test_path = os.path.join(path, inkscape_exe_name)
+                        if os.path.isfile(test_path) and os.access(test_path, os.X_OK):
+                            inkscape_executable = test_path
+                            logger.info("Inkscape executable found as `%s`" % inkscape_executable)
+                            break
+                if inkscape_executable is None:
+                    logger.error("No Inkscape executable found in system path.")
+                    exit(EXIT_BAD_COMMAND_LINE_ARGUMENT_VALUE)
+
+            # Query the system extension path
+            [args.inkscape_extensions_path, err] = defaults.inkscape_system_extensions_path(
+                inkscape_executable)
+            if args.inkscape_extensions_path is None:
+                logger.error("Determination of system extension directory failed (Error message: %s)" % err)
+                exit(EXIT_BAD_COMMAND_LINE_ARGUMENT_VALUE)
+            else:
+                logger.info("System extensions are in %s" % args.inkscape_extensions_path)
+
+            # Check write access in system extension path
+            if not os.access(args.inkscape_extensions_path, os.W_OK):
+                logger.error(
+                    "You do not have write privileges in `%s`! Please run setup script as administrator/ with sudo."
+                    % args.inkscape_extensions_path)
+                exit(EXIT_BAD_COMMAND_LINE_ARGUMENT_VALUE)
+        else:
+            # local installation
+            args.inkscape_extensions_path = os.path.expanduser(args.inkscape_extensions_path)
 
         if args.keep_previous_installation_files is None:
             found_files_to_keep = {}

--- a/textext/base.py
+++ b/textext/base.py
@@ -94,7 +94,7 @@ class TexText(inkex.EffectExtension):
     def __init__(self):
 
         self.config = Settings(directory=defaults.textext_config_path)
-        self.cache = Cache()
+        self.cache = Cache(directory=defaults.textext_config_path)
         previous_exit_code = self.cache.get("previous_exit_code", None)
 
         if previous_exit_code is None:

--- a/textext/base.py
+++ b/textext/base.py
@@ -33,6 +33,10 @@ EXIT_CODE_OK = 0
 EXIT_CODE_EXPECTED_ERROR = 1
 EXIT_CODE_UNEXPECTED_ERROR = 60
 
+LOG_LOCATION = os.path.join(defaults.textext_logfile_path)
+if not os.path.isdir(LOG_LOCATION):
+    os.makedirs(LOG_LOCATION)
+LOG_FILENAME = os.path.join(LOG_LOCATION, "textext.log")  # todo: check destination is writeable
 
 # There are two channels `file_log_channel` and `user_log_channel`
 # `file_log_channel` dumps detailed log to a file
@@ -46,27 +50,6 @@ __logger.setLevel(logging.DEBUG)
 
 log_formatter = logging.Formatter('[%(asctime)s][%(levelname)8s]: %(message)s          //  %(filename)s:%(lineno)-5d')
 
-user_formatter = logging.Formatter('[%(name)s][%(levelname)6s]: %(message)s')
-user_log_channel = CycleBufferHandler(capacity=1024)  # store up to 1024 messages
-user_log_channel.setLevel(logging.DEBUG)
-user_log_channel.setFormatter(user_formatter)
-
-__logger.addHandler(user_log_channel)
-
-SCRIPT_LOCATION=os.path.dirname(__file__)
-LOG_LOCATION=None
-if os.access(SCRIPT_LOCATION, os.W_OK):
-    LOG_LOCATION=SCRIPT_LOCATION
-elif os.access(defaults.inkscape_extensions_path, os.W_OK):
-    LOG_LOCATION=defaults.inkscape_extensions_path
-else:
-    LOG_LOCATION=os.getcwd()
-
-if not os.path.isdir(LOG_LOCATION):
-    os.makedirs(LOG_LOCATION)
-
-LOG_FILENAME = os.path.join(LOG_LOCATION, "textext.log")
-
 file_log_channel = logging.handlers.RotatingFileHandler(LOG_FILENAME,
                                                         maxBytes=500 * 1024,  # up to 500 kB
                                                         backupCount=2,  # up to two log files
@@ -75,7 +58,13 @@ file_log_channel = logging.handlers.RotatingFileHandler(LOG_FILENAME,
 file_log_channel.setLevel(logging.NOTSET)
 file_log_channel.setFormatter(log_formatter)
 
+user_formatter = logging.Formatter('[%(name)s][%(levelname)6s]: %(message)s')
+user_log_channel = CycleBufferHandler(capacity=1024)  # store up to 1024 messages
+user_log_channel.setLevel(logging.DEBUG)
+user_log_channel.setFormatter(user_formatter)
+
 __logger.addHandler(file_log_channel)
+__logger.addHandler(user_log_channel)
 
 import inkex
 from lxml import etree
@@ -104,7 +93,7 @@ class TexText(inkex.EffectExtension):
 
     def __init__(self):
 
-        self.config = Settings(directory=os.path.dirname(os.path.realpath(__file__)))
+        self.config = Settings(directory=defaults.textext_config_path)
         self.cache = Cache()
         previous_exit_code = self.cache.get("previous_exit_code", None)
 

--- a/textext/base.py
+++ b/textext/base.py
@@ -33,11 +33,6 @@ EXIT_CODE_OK = 0
 EXIT_CODE_EXPECTED_ERROR = 1
 EXIT_CODE_UNEXPECTED_ERROR = 60
 
-LOG_LOCATION = os.path.join(defaults.textext_logfile_path)
-if not os.path.isdir(LOG_LOCATION):
-    os.makedirs(LOG_LOCATION)
-LOG_FILENAME = os.path.join(LOG_LOCATION, "textext.log")  # todo: check destination is writeable
-
 # There are two channels `file_log_channel` and `user_log_channel`
 # `file_log_channel` dumps detailed log to a file
 # `user_log_channel` accumulates log messages to show them to user via .show_messages() function
@@ -47,9 +42,22 @@ logging.setLoggerClass(MyLogger)
 __logger = logging.getLogger('TexText')
 logger = NestedLoggingGuard(__logger)
 __logger.setLevel(logging.DEBUG)
-
 log_formatter = logging.Formatter('[%(asctime)s][%(levelname)8s]: %(message)s          //  %(filename)s:%(lineno)-5d')
 
+# First install the user logger so in case anything fails with the file logger
+# we have at least some information in the abort dialog
+# Contributed by Thermi@github.com
+user_formatter = logging.Formatter('[%(name)s][%(levelname)6s]: %(message)s')
+user_log_channel = CycleBufferHandler(capacity=1024)  # store up to 1024 messages
+user_log_channel.setLevel(logging.DEBUG)
+user_log_channel.setFormatter(user_formatter)
+__logger.addHandler(user_log_channel)
+
+# Now we try to install the file logger.
+LOG_LOCATION = os.path.join(defaults.textext_logfile_path)
+if not os.path.isdir(LOG_LOCATION):
+    os.makedirs(LOG_LOCATION)
+LOG_FILENAME = os.path.join(LOG_LOCATION, "textext.log") # ToDo: When not writable continue but give a message somewhere
 file_log_channel = logging.handlers.RotatingFileHandler(LOG_FILENAME,
                                                         maxBytes=500 * 1024,  # up to 500 kB
                                                         backupCount=2,  # up to two log files
@@ -57,14 +65,7 @@ file_log_channel = logging.handlers.RotatingFileHandler(LOG_FILENAME,
                                                         )
 file_log_channel.setLevel(logging.NOTSET)
 file_log_channel.setFormatter(log_formatter)
-
-user_formatter = logging.Formatter('[%(name)s][%(levelname)6s]: %(message)s')
-user_log_channel = CycleBufferHandler(capacity=1024)  # store up to 1024 messages
-user_log_channel.setLevel(logging.DEBUG)
-user_log_channel.setFormatter(user_formatter)
-
 __logger.addHandler(file_log_channel)
-__logger.addHandler(user_log_channel)
 
 import inkex
 from lxml import etree

--- a/textext/requirements_check.py
+++ b/textext/requirements_check.py
@@ -35,6 +35,20 @@ class Defaults(object):
     @abc.abstractproperty
     def inkscape_user_extensions_path(self): pass
 
+    def inkscape_system_extensions_path(self, inkscape_exe_path):
+        try:
+            stdout, stderr = self.call_command([inkscape_exe_path, "--system-data-directory"])
+            path = os.path.join(stdout.decode("utf-8", 'ignore').rstrip(), "extensions")
+            err = None
+        except subprocess.CalledProcessError as excpt:
+            path = None
+            err = "Command `%s` failed, stdout: `%s`, stderr: `%s`" % (excpt.cmd, excpt.stdout, excpt.stderr)
+        except UnicodeDecodeError as excpt:
+            path = None
+            err = excpt.reason
+
+        return [path, err]
+
     @abc.abstractproperty
     def textext_config_path(self): pass
 
@@ -52,7 +66,7 @@ class Defaults(object):
 class LinuxDefaults(Defaults):
     os_name = "linux"
     console_colors = "always"
-    executable_names = {"inkscape": ["inkscape.beta", "inkscape"],   # BETA-TEST only #
+    executable_names = {"inkscape": ["inkscape"],
                         "pdflatex": ["pdflatex"],
                         "lualatex": ["lualatex"],
                         "xelatex": ["xelatex"]
@@ -155,7 +169,6 @@ class WindowsDefaults(Defaults):
     @property
     def textext_logfile_path(self):
         return os.path.join(os.getenv("APPDATA"), "textext")
-
 
     def get_system_path(self):
         return self._tweaked_syspath

--- a/textext/requirements_check.py
+++ b/textext/requirements_check.py
@@ -33,7 +33,13 @@ class Defaults(object):
     def executable_names(self): pass
 
     @abc.abstractproperty
-    def inkscape_extensions_path(self): pass
+    def inkscape_user_extensions_path(self): pass
+
+    @abc.abstractproperty
+    def textext_config_path(self): pass
+
+    @abc.abstractproperty
+    def textext_logfile_path(self): pass
 
     @abc.abstractmethod
     def get_system_path(self): pass
@@ -53,8 +59,16 @@ class LinuxDefaults(Defaults):
                         }
 
     @property
-    def inkscape_extensions_path(self):
+    def inkscape_user_extensions_path(self):
         return os.path.expanduser("~/.config/inkscape/extensions")
+
+    @property
+    def textext_config_path(self):
+        return os.path.expanduser("~/.config/textext")
+
+    @property
+    def textext_logfile_path(self):
+        return os.path.expanduser("~/.cache/textext")
 
     def get_system_path(self):
         return os.environ["PATH"].split(os.path.pathsep)
@@ -82,8 +96,16 @@ class MacDefaults(LinuxDefaults):
         return path
 
     @property
-    def inkscape_extensions_path(self):
+    def inkscape_user_extensions_path(self):
         return os.path.expanduser("~/Library/Application Support/org.inkscape.Inkscape/config/inkscape/extensions")
+
+    @property
+    def textext_config_path(self):
+        return os.path.expanduser("~/Library/Preferences/textext")
+
+    @property
+    def textext_logfile_path(self):
+        return os.path.expanduser("~/Library/Preferences/textext")
 
 
 class WindowsDefaults(Defaults):
@@ -123,8 +145,17 @@ class WindowsDefaults(Defaults):
             pass
 
     @property
-    def inkscape_extensions_path(self):
+    def inkscape_user_extensions_path(self):
         return os.path.join(os.getenv("APPDATA"), "inkscape", "extensions")
+
+    @property
+    def textext_config_path(self):
+        return os.path.join(os.getenv("APPDATA"), "textext")
+
+    @property
+    def textext_logfile_path(self):
+        return os.path.join(os.getenv("APPDATA"), "textext")
+
 
     def get_system_path(self):
         return self._tweaked_syspath

--- a/textext/utility.py
+++ b/textext/utility.py
@@ -196,9 +196,9 @@ class Settings(object):
 
 
 class Cache(Settings):
-    def __init__(self, basename=".cache.json"):
+    def __init__(self, basename=".cache.json", directory=None):
         try:
-            super(Cache, self).__init__(basename)
+            super(Cache, self).__init__(basename, directory)
         except TexTextFatalError:
             pass
 

--- a/textext/utility.py
+++ b/textext/utility.py
@@ -163,6 +163,9 @@ class Settings(object):
     def __init__(self, basename="config.json", directory=None):
         if directory is None:
             directory = os.getcwd()
+        else:
+            if not os.path.exists(directory):
+                os.makedirs(directory, exist_ok=True)
         self.values = {}
         self.config_path = os.path.join(directory, basename)
         try:


### PR DESCRIPTION
This pull request addresses two subjects:

- when TexText is installed system wide it is ensured that no files are written into the install location (which usually is read only for the user)
- the setup script offers an option `--all-users` which will install TexText into the system extension dir of Inkscape

In order to make this work it must be ensured that `textext.log` and `config.json` go into a directory which has write acces for the user. I decided to put these files into the following directories:

~- Linux: `~/.config/textext`~
~- Windows: `C:\Users\Username\AppData\Roaming\textext`~
~- Mac: `~/Library/Application Support/org.inkscape.Inkscape/config/textext`~

**Linux:**
- Settings: `~/.config/textext/config.json`
- Logs: `~/.cache/textext/textext.log`

**Windows:** (%APPDATA% = C:\Users\Username\AppData\Roaming)
- Settings: `%APPDATA%\textext\config.json`
- Logs: `%APPDATA%\textext\textext.log`

**MacOS X** (after some additional research)
- Settings: `~/Library/Preferences/config.json`
- Logs: `~/Library/Preferences/textext.log`


As a side effect it is ensured that these files are always in the same location independtly of the method how TexText has been installed (from the command line, via extension manager + file, via extension manager + extension repo, via a package manager)

Relates to #314, #247, #315

ToDo list
- [x] Log file into new location
- [x] settings into new location
- [x] Make `--all-users` option work

Short checklist:
- [x] Tested with Inkscape version: 1.1
- [x] Tested on Linux, Distro: Kubuntu 20.04
- [x] Tested on Windows, Version: 8.1 and 10 21H1
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
