### PR TITLE
Fixed: ResourceWarning error when reading TeX-code from file

### DIFF
--- a/textext/asktext.py
+++ b/textext/asktext.py
@@ -648,7 +648,8 @@ class AskTextGTKSource(AskText):
         """
 
         try:
-            text = open(path).read()
+            with open(path) as file_handle:
+                text = file_handle.read()
         except IOError:
             print("Couldn't load file: %s", path)
             return False


### PR DESCRIPTION
When reading TeX code from a file (File - Open menu in TexText dialog) the following error is shown in TexText 1.6.0:

`ResourceWarning: unclosed file <_io.TextIOWrapper name'...'`

This patch fixes this error.

Closes #322