### PR TITLE
Replace dependency on distutils with manual version parsing.

### DIFF
--- a/textext/requirements_check.py
+++ b/textext/requirements_check.py
@@ -620,18 +620,17 @@ class TexTextRequirementsChecker(object):
         return RequirementCheckResult(True, ["TkInter is found"])
 
     def find_inkscape_1_0(self):
-        from distutils.version import LooseVersion
         try:
             executable = self.find_executable('inkscape')['path']
             stdout, stderr = defaults.call_command([executable, "--version"])
         except (KeyError, OSError):
             return RequirementCheckResult(False, ["inkscape is not found"])
         for stdout_line in stdout.decode("utf-8", 'ignore').split("\n"):
-            m = re.search(r"Inkscape (\d+.\d+[-\w]*)", stdout_line)
+            m = re.search(r"Inkscape ((\d+).(\d+)[.\d+][-\w]*)", stdout_line)
 
             if m:
-                found_version = m.group(1)
-                if LooseVersion(found_version) >= LooseVersion("1.0"):
+                found_version, major, minor = m.groups()
+                if int(major) >= 1:
                     return RequirementCheckResult(True, ["inkscape=%s is found" % found_version], path=executable)
                 else:
                     return RequirementCheckResult(False, [

--- a/textext/requirements_check.py
+++ b/textext/requirements_check.py
@@ -626,7 +626,7 @@ class TexTextRequirementsChecker(object):
         except (KeyError, OSError):
             return RequirementCheckResult(False, ["inkscape is not found"])
         for stdout_line in stdout.decode("utf-8", 'ignore').split("\n"):
-            m = re.search(r"Inkscape ((\d+).(\d+)[.\d+][-\w]*)", stdout_line)
+            m = re.search(r"Inkscape ((\d+)\.(\d+)[-\w]*)", stdout_line)
 
             if m:
                 found_version, major, minor = m.groups()


### PR DESCRIPTION
The python standard module `distutils` is deprecated as of Python 3.10 and scheduled for removal.  textext depends on distutils for parsing the version of the inkscape binary, which results in an ugly warning in inkscape.

We replace the version parsing with a simple regex.

Short checklist:
- [X] Tested with Inkscape version: 1.1.1
- [X] Tested on Linux, Distro: Arch
