### PR TITLE
Feature/user units inkscape 1.2

### DIFF
--- a/snippets/empty_i1_1_0.svg
+++ b/snippets/empty_i1_1_0.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg911"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="empty_i1_1_0.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview913"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.64052329"
+     inkscape:cx="397.33138"
+     inkscape:cy="561.25984"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs908" />
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1" />
+</svg>

--- a/snippets/empty_i1_1_0_in.svg
+++ b/snippets/empty_i1_1_0_in.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="8.5in"
+   height="11in"
+   viewBox="0 0 215.9 279.4"
+   version="1.1"
+   id="svg4930"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="empty_i1_1_0_in.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview4932"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="in"
+     showgrid="false"
+     units="in"
+     inkscape:zoom="0.83996212"
+     inkscape:cx="407.75648"
+     inkscape:cy="528"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4927" />
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1" />
+</svg>

--- a/snippets/empty_i1_1_0_px.svg
+++ b/snippets/empty_i1_1_0_px.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="793.70081"
+   height="1122.5197"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg911"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="empty_i1_1_0_px.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview913"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="px"
+     showgrid="false"
+     inkscape:zoom="0.64052329"
+     inkscape:cx="397.33138"
+     inkscape:cy="561.25984"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     units="px" />
+  <defs
+     id="defs908" />
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1" />
+</svg>

--- a/snippets/empty_i1_2_0.svg
+++ b/snippets/empty_i1_2_0.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg382"
+   inkscape:version="1.2-dev (9dacc2cb3b, 2021-12-27, custom)"
+   sodipodi:docname="empty_i1_2_0.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview384"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:blackoutopacity="0.0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.64497755"
+     inkscape:cx="396.13782"
+     inkscape:cy="560.48462"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs379" />
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1" />
+</svg>

--- a/snippets/empty_i1_2_0_in.svg
+++ b/snippets/empty_i1_2_0_in.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="8.5in"
+   height="11in"
+   viewBox="0 0 215.9 279.4"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2-dev (9dacc2cb3b, 2021-12-27, custom)"
+   sodipodi:docname="empty_i1_2_0_in.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:blackoutopacity="0.0"
+     inkscape:document-units="in"
+     showgrid="false"
+     inkscape:zoom="0.79553171"
+     inkscape:cx="396.5901"
+     inkscape:cy="561.25984"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1" />
+</svg>

--- a/snippets/empty_i1_2_0_px.svg
+++ b/snippets/empty_i1_2_0_px.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="793"
+   height="1122"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg382"
+   inkscape:version="1.2-dev (9dacc2cb3b, 2021-12-27, custom)"
+   sodipodi:docname="empty_i1_2_0_px.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview384"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:blackoutopacity="0.0"
+     inkscape:document-units="px"
+     showgrid="false"
+     inkscape:zoom="0.64497755"
+     inkscape:cx="396.13782"
+     inkscape:cy="560.48462"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs379" />
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1" />
+</svg>

--- a/textext/base.py
+++ b/textext/base.py
@@ -22,7 +22,7 @@ from io import open # ToDo: For open utf8, remove when Python 2 support is skipp
 
 from .requirements_check import defaults, set_logging_levels, TexTextRequirementsChecker
 from .utility import ChangeToTemporaryDirectory, CycleBufferHandler, MyLogger, NestedLoggingGuard, Settings, Cache, \
-    exec_command, check_minimal_required_version
+    exec_command, version_greater_or_equal_than
 from .errors import *
 
 with open(os.path.join(os.path.dirname(__file__), "VERSION")) as version_file:
@@ -396,7 +396,7 @@ class TexText(inkex.EffectExtension):
                     # not in doc units! Hence, we need to convert the value to the document unit.
                     # so the transform is correct later.
                     if hasattr(inkex, "__version__"):
-                        if check_minimal_required_version(inkex.__version__, "1.2.0"):
+                        if version_greater_or_equal_than(inkex.__version__, "1.2.0"):
                             view_center.x = self.svg.uutounit(view_center.x, self.svg.unit)
                             view_center.y = self.svg.uutounit(view_center.y, self.svg.unit)
 

--- a/textext/utility.py
+++ b/textext/utility.py
@@ -20,6 +20,7 @@ import shutil
 import stat
 import subprocess
 import tempfile
+import re
 
 from .errors import *
 import sys
@@ -257,6 +258,38 @@ def exec_command(cmd, ok_return_value=0):
                                    stdout=out,
                                    stderr=err)
     return out + err
+
+
+def check_minimal_required_version(actual_version_str, required_version_str):
+    """ Checks if an actual version meets at least a specified version requirement
+
+    Version strings must be of type "N.M.Rarb" where N, M, R are non negative decimal numbers
+    < 1000 and arb is an arbitrary string, e.g. "1.2.3" or "1.2.3dev" or "1.2.3-dev" or "1.2.3 dev"
+
+    Args:
+        required_version_str (str): The required version number
+        actual_version_str (str): The version number to be tested
+
+    Returns:
+        True if the actual version is equal or greater then the required version, otherwise false
+
+    """
+    def ver_str_to_float(ver_str):
+        """ Parse version string and returns them as float
+
+        Returns The version string as floating point number for easy comparison
+        (minor version and relase number padded with zeros). E.g. "1.23.4dev" -> 1.023004.
+        If conversion fails returns NaN.
+
+        """
+        m = re.search(r"(\d+).(\d+).(\d+)[-\w]*", ver_str)
+        if m is not None:
+            ver_maj, ver_min, ver_rel = m.groups()
+            return float("{}.{:0>3}{:0>3}".format(ver_maj, ver_min, ver_rel))
+        else:
+            return float("nan")
+
+    return ver_str_to_float(actual_version_str) >= ver_str_to_float(required_version_str)
 
 
 MAC = "Darwin"

--- a/textext/utility.py
+++ b/textext/utility.py
@@ -260,22 +260,20 @@ def exec_command(cmd, ok_return_value=0):
     return out + err
 
 
-def check_minimal_required_version(actual_version_str, required_version_str):
-    """ Checks if an actual version meets at least a specified version requirement
+def version_greater_or_equal_than(version_str, other_version_str):
+    """ Checks if a version number is >= than another version number
 
-    Version strings must be of type "N.M.Rarb" where N, M, R are non negative decimal numbers
-    < 1000 and arb is an arbitrary string, e.g. "1.2.3" or "1.2.3dev" or "1.2.3-dev" or "1.2.3 dev"
-
-    Args:
-        required_version_str (str): The required version number
-        actual_version_str (str): The version number to be tested
+    Version numbers are passed as strings and must be of type "N.M.Rarb" where N, M, R
+    are non negative decimal numbers < 1000 and arb is an arbitrary string.
+    For example, "1.2.3" or "1.2.3dev" or "1.2.3-dev" or "1.2.3 dev" are valid version strings.
 
     Returns:
-        True if the actual version is equal or greater then the required version, otherwise false
+        True if the version number is equal or greater then the other version number,
+        otherwise false
 
     """
     def ver_str_to_float(ver_str):
-        """ Parse version string and returns them as float
+        """ Parse version string and returns it as a floating point value
 
         Returns The version string as floating point number for easy comparison
         (minor version and relase number padded with zeros). E.g. "1.23.4dev" -> 1.023004.
@@ -289,7 +287,7 @@ def check_minimal_required_version(actual_version_str, required_version_str):
         else:
             return float("nan")
 
-    return ver_str_to_float(actual_version_str) >= ver_str_to_float(required_version_str)
+    return ver_str_to_float(version_str) >= ver_str_to_float(other_version_str)
 
 
 MAC = "Darwin"


### PR DESCRIPTION
Related issue(s): Resolves #338 

Pull request addresses the fact that in Inkscape 1.2. the extension API method [`unittouu`](https://inkscape.gitlab.io/extensions/documentation/source/inkex.elements._base.html#inkex.elements._base.BaseElement.unittouu) always converts a value into px and not into the units specified by the user. Hence, the view_center is always returned in px now and not in the units selected by the user in its document. Depending on the API version the view_center coordinates are converted into the correct unit now.
```python
# Since Inkscape 1.2 (= extension API version 1.2.0) view_center is in px,
# not in doc units! Hence, we need to convert the value to the document unit,
# so the transform is correct later.
if hasattr(inkex, "__version__"):
   if check_minimal_required_version(inkex.__version__, "1.2.0"):
   view_center.x = self.svg.uutounit(view_center.x, self.svg.unit)
   view_center.y = self.svg.uutounit(view_center.y, self.svg.unit)
```
([Code reference...](https://github.com/jcwinkler/textext/blob/311bd762292178227a0b7de0ef45d78ebdbc77f7/textext/base.py#L395-L401))

I also reworked the scaling of the poppler output. It is not scaled in mm now but in the units used by the user in the document:
```python
# Ensure that snippet is correctly scaled according to the units of the document
# We scale it here such that its size is correct in the document units
# (Usually pt returned from poppler to mm in the main document)
self.transform.add_scale(root.uutounit("1{}".format(root.unit), document_unit))
```

([Code reference...](https://github.com/jcwinkler/textext/blob/311bd762292178227a0b7de0ef45d78ebdbc77f7/textext/base.py#L667-L670)...)


I tested it with documents in differnt units (inch, mm, px) and it seems to work now.

Further changes:

- Some test snippets
- Helper function `check_minimal_required_version` in `utility.py`

@sizmailov Would you agree with this approach? 

Short checklist:
- [x] Tested with Inkscape version: 1.1 and 1.2-dev
- [x] Tested on Linux Kubuntu 20.04
- [x] Tested on Windows 8.1 and 10 21H2
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
