### PR TITLE
Allow optional \documentclass or \documentstyle in preamble

### DIFF
--- a/docs/source/usage/faq.rst
+++ b/docs/source/usage/faq.rst
@@ -54,6 +54,17 @@ The resulting text should be of equal height as if has been typeset directly in 
 .. figure:: ../images/texttext-fontsize-example.png
    :alt: Font size example
 
+If you want to change the default font size you can do that by specifying it in the
+:ref:`usage-preamble-file`.
+
+.. code-block:: latex
+
+    \documentclass[12pt]{article}
+    % ***rest of the preamble file***
+
+This is convenient, e.g., if you want to create multiple nodes with the same,
+specific font size.
+
 .. _faq-font-custom-font:
 
 Selection of special fonts

--- a/docs/source/usage/gui.rst
+++ b/docs/source/usage/gui.rst
@@ -175,9 +175,11 @@ Preamble file
 Be aware of including the required packages in the *preamble file* if you
 use special commands in your code that rely on such packages. The
 preamble file can be chosen by the selector |usage-label-2|. The default preamble
-file shipped with |TexText| includes the following packages:
+file shipped with |TexText| includes the following:
 
 .. code-block:: latex
+
+    \documentclass{article}
 
     \usepackage{amsmath,amsthm,amssymb,amsfonts}
     \usepackage{color}
@@ -186,7 +188,6 @@ Basically, your LaTeX code will be inserted into this environment:
 
 .. code-block:: latex
 
-    \documentclass{article}
     % ***preamble file content***
     \pagestyle{empty}
     \begin{document}
@@ -194,7 +195,8 @@ Basically, your LaTeX code will be inserted into this environment:
     \end{document}
 
 This will be typeset, converted to SVG and inserted into your Inkscape
-document.
+document. If no :latex:`\documentclass` or :latex:`\documentstyle` is specified
+in the preamble file, :latex:`\documentclass{article}` is used by default.
 
 .. _usage-scaling:
 

--- a/textext/base.py
+++ b/textext/base.py
@@ -505,8 +505,8 @@ class TexToPdfConverter:
     """
     Base class for Latex -> SVG converters
     """
+    DEFAULT_DOCUMENT_CLASS=r"\documentclass{article}"
     DOCUMENT_TEMPLATE = r"""
-    \documentclass{article}
     %s
     \pagestyle{empty}
     \begin{document}
@@ -542,6 +542,10 @@ class TexToPdfConverter:
             if os.path.isfile(preamble_file):
                 with open(preamble_file, 'r') as f:
                     preamble += f.read()
+
+            # Add default document class to preamble if necessary
+            if not _contains_document_class(preamble):
+                preamble = self.DEFAULT_DOCUMENT_CLASS + preamble
 
             # Options pass to LaTeX-related commands
 
@@ -634,6 +638,22 @@ class TexToPdfConverter:
                 return parser.errors[0]
             except Exception as ignored:
                 return "TeX compilation failed. See stdout output for more details"
+
+
+def _contains_document_class(preamble):
+    """Return True if `preamble` contains a documentclass-like command.
+    
+    Also, checks and consideres if the command is commented out or not.
+    """
+    lines = preamble.split("\n")
+    document_commands = ["\documentclass{", "\documentclass[",
+                        "\documentstyle{", "\documentstyle["]
+    for line in lines:
+        for document_command in document_commands:
+            if (document_command in line
+                and "%" not in line.split(document_command)[0]):
+                return True
+    return False
 
 
 class TexTextElement(inkex.Group):

--- a/textext/base.py
+++ b/textext/base.py
@@ -643,7 +643,7 @@ class TexToPdfConverter:
 def _contains_document_class(preamble):
     """Return True if `preamble` contains a documentclass-like command.
     
-    Also, checks and consideres if the command is commented out or not.
+    Also, checks and considers if the command is commented out or not.
     """
     lines = preamble.split("\n")
     document_commands = ["\documentclass{", "\documentclass[",

--- a/textext/default_packages.tex
+++ b/textext/default_packages.tex
@@ -1,2 +1,4 @@
+\documentclass{article}
+
 \usepackage{amsmath,amsthm,amssymb,amsfonts}
 \usepackage{color}


### PR DESCRIPTION
Related issue(s): none

Precise description of the changes proposed in the pull request:

**Reasoning**: My reason for this PR is that I want to create figures for a document where the normal font size is set to 11pt (instead of the default 10pt) and I do not want to manually specify that font size in every textext cell. The proposed change allows to have a `documentclass`-like command in the preamble which makes it easy to "globally" specify things like the normal font size. The change does not alter the behavior for preambles without such a command. It is fully backwards compatible.

**Implementation**: I moved `\documentclass{article}` from the `DOCUMENT_TEMPLATE` into its own constant called `DEFAULT_DOCUMENT_CLASS`. This constant is only prepended to `preamble` if it does not contain a `\documentclass` or `\documentstyle` command. To check this I added the function `_contains_document_class(preamble)` which parses the preamble for those commands and also makes sure that they are not commented out.

Short checklist:
- [x] Tested with Inkscape version: 1.0.2-2
- [ ] Tested on Linux, Distro:
- [x] Tested on Windows, Version: Windows 10 Home (19042.1466)
- [ ] Tested on MacOS, Version:
