### PR TITLE
Hotfix/setup portable apps

### DIFF
--- a/docs/source/install/advanced.rst
+++ b/docs/source/install/advanced.rst
@@ -20,13 +20,11 @@ options to adapt the installation process to your system configuration:
 
 --inkscape-extensions-path INKSCAPE_EXTENSIONS_PATH
     Path to inkscape extensions directory. Use this if the user
-    extensions are installed in an unusual place, e.g. when using |Inkscape|
-    in PortableApps on Windows.
+    extensions are installed in an unusual place.
 
 --inkscape-executable INKSCAPE_EXECUTABLE
     Full path to inkscape executable.  Use this if |Inkscape| is not found
-    automatically by the setup script (Test- or Beta-installations, Portable
-    Apps on Windows).
+    automatically by the setup script (Test- or Beta-installations).
 
 --pdflatex-executable PDFLATEX_EXECUTABLE
     Full path to pdflatex executable.
@@ -36,6 +34,18 @@ options to adapt the installation process to your system configuration:
 
 --xelatex-executable XELATEX_EXECUTABLE
     Full path to xelatex executable.
+
+--portable-apps-dir INSTALLATION_DIRECTORY_OF_PORTABLEAPPS
+    Windows only: If you use Inkscape from PortableApps use this parameter
+    to specifiy the directory into which PortableApps has been installed, e.g.
+    ``C:\Users\YourUserName\PortableApps``. It ensures that |TexText| is
+    installed correctly into the PortableApps structure.
+
+    .. attention::
+        If you also have your LaTeX distribution installed in PortableApps
+        you need to specify the paths to the latex executables by
+        using the ``--pdflatex-executable`` and/or ``--lualatex-executable``
+        and/or ``--xelatex-executable`` arguments.
 
 --skip-requirements-check
     Bypass minimal requirements check. |TexText| will be installed even if

--- a/docs/source/install/windows.rst
+++ b/docs/source/install/windows.rst
@@ -21,6 +21,8 @@
 |TexText| on Windows
 ====================
 
+If you use Inkscape in PortableApps please go to `these special instructions <portableapps-install_>`_.
+
 .. _windows-install-preparation:
 
 Preparation
@@ -118,3 +120,32 @@ Problems with the GUI framework
 The GUI framework should already be included in the Inkscape installation on Windows.
 Hence, if the |TexText| installer complains about missing GTK3 or TkInter bindings
 please file a bug report on `github <https://github.com/textext/textext/issues/new/choose>`_
+
+.. _portableapps-install:
+
+Installation for Inkscape in PortableApps
+=========================================
+
+If you use Inkscape in PortableApps you have to proceed as follows:
+
+1. Download the most recent package from :textext_current_release_page:`GitHub release page <release>` (direct links: :textext_download_zip:`.zip <Windows>`)
+2. Extract the package and change into the created directory.
+3. Open a Windows command prompt or Windows power shell window  in this directory
+   (``SHIFT`` + right-click in the Windows explorer, then select `Open powershell window here`)
+4. Enter and execute the following command where ``C:\Path\To\Your\PartableApps\Installation``
+   is the path to your PortableApps installation (usually this is ``C:\User\YourUserName\PortableApps``):
+
+   .. code-block:: bash
+
+        setup_win.bat --portable-apps-dir "C:\Path\To\Your\PartableApps\Installation"
+
+   If you also use your LaTeX system from PortableApps use the following command instead:
+
+   .. code-block:: bash
+
+        setup_win.bat --portable-apps-dir "C:\Path\To\Your\PartableApps\Installation" --pdflatex-executable "C:\Path\To\pdflatex.exe"
+
+   (use ``--lualatex-executable`` and ``--xelatex-executable`` if you also want to have
+   lualatex and xelatex available as well)
+
+   See :ref:`advanced-install` for further options provided by :bash:`setup_win.bat`.

--- a/setup.py
+++ b/setup.py
@@ -334,8 +334,7 @@ if __name__ == "__main__":
     fh.setFormatter(formatter)
     logger.addHandler(fh)
 
-    # Address special Portable Apps directory structure, we cannot do requirement checks
-    # because we run setup from outside of PortableApps
+    # Address special Portable Apps directory structure
     if args.portable_apps_dir:
         if not os.path.isdir(args.portable_apps_dir):
             logger.error("Path specified for PortableApps is not a valid directory!")
@@ -347,7 +346,6 @@ if __name__ == "__main__":
                                                 "InkscapePortable\\App\\Inkscape\\bin\\inkscape.exe")
         args.inkscape_extensions_path = os.path.join(args.portable_apps_dir,
                                                      "InkscapePortable\\Data\\settings\\extensions")
-        args.skip_requirements_check = True
         settings = Settings(directory=os.path.join(args.portable_apps_dir, "InkscapePortable\\Data\\settings\\textext"))
     else:
         settings = Settings(directory=defaults.textext_config_path)

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -50,10 +50,10 @@ if defined args (
 			rem Check for explicitely given inkscape executable
 			if /I "%%C"=="inkscape-executable" if not "%%D"=="" (
 				if not exist "%%D" (
-					echo %%D not found!
+					echo Specified directory %%D for Inkscape executable not found!
 					goto FINAL
 				) else (
-					echo %%D found!
+				    rem Just take the path from %%D
 					set INKSCAPE_DIR=%%~dpD
 				)				
 			) else (
@@ -63,12 +63,16 @@ if defined args (
 			rem Check for given --portable-apps-dir argument
 			if /I "%%C"=="portable-apps-dir" if not "%%D"=="" (
 				if not exist "%%D" (
-					echo %%D not found!
+					echo Specified PortableApps directory %%D not found!
 					goto FINAL
 				) else (
-					echo %%D found!
-					set INKSCAPE_DIR=%%D\InkscapePortable\App\Inkscape\bin
-				)				
+					set arg=%%D
+					rem Remove quotes
+					set arg=!arg:"=%!
+					rem Remove possible trailing whitespaces
+					if "!arg:~-1!"==" " set arg=!arg:~0,-1!
+					set INKSCAPE_DIR=!arg!\InkscapePortable\App\Inkscape\bin
+				)
 			) else (
 				echo No value specified for key --%%C
 				goto PRINT_USAGE
@@ -233,9 +237,9 @@ set PYTHON_EXE="%INKSCAPE_DIR%\python.exe"
 if exist "%PYTHON_EXE%" (
     echo %PYTHON_EXE% found
     echo.
-    
-goto RUN_SETUP_PY
+    goto RUN_SETUP_PY
 ) else (
+    echo %PYTHON_EXE% not found!
 	goto PYTHON_NOT_FOUND
 )
 

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -60,6 +60,19 @@ if defined args (
 				echo No value specified for key --%%C
 				goto PRINT_USAGE
 			)
+			rem Check for given --portable-apps-dir argument
+			if /I "%%C"=="portable-apps-dir" if not "%%D"=="" (
+				if not exist "%%D" (
+					echo %%D not found!
+					goto FINAL
+				) else (
+					echo %%D found!
+					set INKSCAPE_DIR=%%D\InkscapePortable\App\Inkscape\bin
+				)				
+			) else (
+				echo No value specified for key --%%C
+				goto PRINT_USAGE
+			)
 			set PYTHON_ARGS=!PYTHON_ARGS!--%%A
 		)
 		rem Repeat operation with remaining argument list


### PR DESCRIPTION
Versions of TexText > 1.5 did not work in Inkscape for PortableApps on Windows. Reason was the changed location of the settings file (commit f587311354eed0e0bd4101d13b4b3bc3f586a142). This is now addressed by introducing the new command line argument `--portable-apps-dir` in the setup script. It places everything correctly now.

Resolves #288

Short checklist:
- [x] Tested with Inkscape version: 1.1.1 (PortableApps)
- [x] Tested on Windows 10

(Linux and Mac are not affected)

