### PR TITLE
Hotfix: Settings from old setup not deleted/overwritten during new setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -368,6 +368,8 @@ if __name__ == "__main__":
                 exit(EXIT_BAD_COMMAND_LINE_ARGUMENT_VALUE)
 
             settings["%s-executable" % executable_name] = executable_path
+        else:
+            settings["%s-executable" % executable_name] = None
 
     if not args.skip_requirements_check:
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from textext.requirements_check import \
     LoggingColors, \
     SUCCESS
 
-from textext.utility import Settings
+from textext.utility import Settings, Cache
 
 
 # Hotfix for Inkscape 1.0.1 on Windows: HarfBuzz-0.0.typelib is missing
@@ -349,6 +349,9 @@ if __name__ == "__main__":
         settings = Settings(directory=os.path.join(args.portable_apps_dir, "InkscapePortable\\Data\\settings\\textext"))
     else:
         settings = Settings(directory=defaults.textext_config_path)
+
+    CachedSettings = Cache(directory=settings.directory)
+    CachedSettings.delete_file()
 
     checker = TexTextRequirementsChecker(logger, settings)
 

--- a/textext/utility.py
+++ b/textext/utility.py
@@ -168,6 +168,7 @@ class Settings(object):
             if not os.path.exists(directory):
                 os.makedirs(directory, exist_ok=True)
         self.values = {}
+        self.directory = directory
         self.config_path = os.path.join(directory, basename)
         try:
             self.load()

--- a/textext/utility.py
+++ b/textext/utility.py
@@ -190,6 +190,14 @@ class Settings(object):
             return default
         return result
 
+    def delete_file(self):
+        if os.path.exists(self.config_path):
+            try:
+                os.remove(self.config_path)
+            except OSError as err:
+                TexTextFatalError("Config `%s` could not be deleted. Error message: %s" % (
+                                  self.config_path, str(err)))
+
     def __getitem__(self, key):
         return self.values.get(key)
 

--- a/textext/utility.py
+++ b/textext/utility.py
@@ -202,7 +202,10 @@ class Settings(object):
         return self.values.get(key)
 
     def __setitem__(self, key, value):
-        self.values[key] = value
+        if value is not None:
+            self.values[key] = value
+        else:
+            self.values.pop(key, None)
 
 
 class Cache(Settings):


### PR DESCRIPTION
A weakness in the current setup procedure implemented in `setup.py` has been discovered (cf. issue #345):

When a user re-installs TexText and he changes the user defined paths to executables this change is not recognized by TexText.

The reason for this is twofold:

1. The `.cache.json` file is not deleted when TexText is re-installed. Hence, when TexText is invoked again, it uses the old `.cache.json` and does not get aware of the changed paths. This is addressed by deleting the `.cache.json` during setup.
2. If the user specified a custom path to an executable in a previous setup run and then re-runs setup without this custom path the old path remains in `config.json`. This is addressed by deleting keys in the settings file when the corresonding executable path is not specified during setup.

Short checklist:
- [x] Tested with Inkscape version: 1.1.2
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [x] Tested on Windows, 8.1
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
