### PR TITLE
Suppress ImportWarning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,11 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
     - name: Install dependencies
       run: |
         sudo add-apt-repository --yes ppa:inkscape.dev/stable
@@ -32,7 +30,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         # Needed by Inkscape extensions and image processing:
-        pip install lxml Pillow
+        pip install lxml cssselect Pillow
     - name: Test installation script
       run: |
         python test_installation_script.py 2> /dev/null

--- a/textext/asktext.py
+++ b/textext/asktext.py
@@ -57,9 +57,29 @@ try:
         os.environ['GI_TYPELIB_PATH'] = os.path.dirname(os.path.abspath(__file__))
 
     import gi
-
     gi.require_version("Gtk", "3.0")
-    from gi.repository import Gtk
+
+    # The import statement
+    # from gi.repository import Gtk
+    # writes a warning into stderr under Python 3.10 which always pops up after the
+    # extensions has been executed:
+    # "DynamicImporter.exec_module() not found; falling back to load_module()"
+    # We redirect stderr here into a string, check if
+    # this warning has been writen and silently discard it. If something else has
+    # been written to stderr we pass it to stderr.
+    # Related issues:
+    # https://gitlab.com/inkscape/extensions/-/issues/463
+    # ToDo: Remove the stuff around the import statement when this has been fixed in
+    #       updated Python 3.10 releases or is properly handled by Inkscape
+    # ======
+    from contextlib import redirect_stderr
+    import io
+    with redirect_stderr(io.StringIO()) as f:
+        from gi.repository import Gtk
+    stderr_str = f.getvalue()
+    if stderr_str.find("ImportWarning: DynamicImporter") == -1:
+        sys.stderr.write(stderr_str)
+    # ======
 
     from gi.repository import Gdk, GdkPixbuf
 


### PR DESCRIPTION
Each time any Inkscape extension with a custom GUI is executed under Python 3.10 the warning
```
<frozen importlib._bootstrap>:671: ImportWarning: DynamicImporter.exec_module() not found; falling back to load_module()
```
is shown. This is pretty annoying. This is a weird workaround to suppress this warning.

Resolves #350

Related to #361, #362

(cherry picked from commit 52d4c03076c3c66a1af081c3b3c8cf3494902064)

