### PR TITLE
Add linting in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 
 jobs:
+
   build:
     runs-on: ubuntu-latest
 
@@ -41,3 +42,21 @@ jobs:
         export PYTHONPATH="`inkscape --system-data-directory`/extensions:$HOME/.config/inkscape/extensions/"
         python -m pytest --verbose -s pytests
         xmllint --noout --relaxng inkscape.extension.rng textext/textext.inx
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ env.pythonLocation }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.pythonLocation }}-pip-
+    - name: Install python dependencies
+      run: pip install lxml cssselect Pillow pylint
+    - name: Run pylint
+      run: pylint textext/ tests/ pytests/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,13 +50,14 @@ jobs:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ env.pythonLocation }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.pythonLocation }}-pip-
-    - name: Install python dependencies
-      run: pip install lxml cssselect Pillow pylint
+    - name: Install dependencies
+      run: |
+        sudo add-apt-repository --yes ppa:inkscape.dev/stable
+        sudo apt update
+        sudo apt install inkscape
+        python -m pip install --upgrade pip
+        pip install lxml cssselect Pillow pylint
     - name: Run pylint
-      run: pylint textext/ tests/ pytests/
+      run: |
+        export PYTHONPATH="`inkscape --system-data-directory`/extensions
+        pylint textext/ tests/ pytests/

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,28 @@
+[BASIC]
+argument-rgx=[a-z_][a-z0-9_]{0,30}
+attr-rgx=[a-z_][a-z0-9_]{0,30}
+const-rgx=[a-z_][a-z0-9_]{0,30}
+variable-rgx=[a-z_][a-z0-9_]{0,30}
+
+[FORMAT]
+max-line-length=120
+
+[MESSAGES CONTROL]
+disable=
+    arguments-differ,
+    fixme,
+    missing-class-docstring,
+    missing-final-newline,
+    missing-function-docstring,
+    missing-module-docstring,
+    no-else-return,
+    too-few-public-methods,
+    too-many-arguments,
+    too-many-boolean-expressions,
+    too-many-branches,
+    too-many-format-args,
+    too-many-instance-attributes,
+    too-many-locals,
+    too-many-nested-blocks,
+    too-many-return-statements,
+    too-many-statements,


### PR DESCRIPTION
Related issue(s):
Closes #377 

Precise description of the changes proposed in the pull request:

Implements linting with pylint in Github Actions and adds a template `.pylintrc`. 