### PR TITLE
Fix `typst.exe` ignored on Windows 

### DIFF
--- a/textext/requirements_check.py
+++ b/textext/requirements_check.py
@@ -132,7 +132,7 @@ class WindowsDefaults(Defaults):
                         "pdflatex": ["pdflatex.exe"],
                         "lualatex": ["lualatex.exe"],
                         "xelatex": ["xelatex.exe"],
-                        "typst": ["typst"]
+                        "typst": ["typst.exe"]
                         }
 
     def __init__(self):


### PR DESCRIPTION
<!--
Thank you for your contribution to TexText. Please make sure you have rebased your work
on the most recent commit of the upstrem `develop` branch and that the pull request targets
the `develop` branch. Additionally, provide the following information before opening this pull request:
-->

Related issue(s): https://github.com/textext/textext/issues/403#issuecomment-1817494909

On Windows, executables end with `.exe`. The setup script thought `typst is NOT found in PATH` by default, because it does not know `typst.exe`. This PR tells it to check `typst.exe`.

Short checklist:
- [ ] Tested with Inkscape version: 1.3 (0e150ed6c4, 2023-07-21)
- [ ] Tested on Linux, Distro: —
- [ ] Tested on Windows, Version: 10
- [ ] Tested on MacOS, Version:  —
- [x] Download the ZIP release of https://github.com/textext/textext/releases/tag/1.10.0 for Windows, apply this PR, and it works.

(Sorry this is a trivial PR so I didn't test rigorously)