### PR TITLE
custumize typst displayMath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.idea/
 /textext/.cache.json
 /textext/config.json
+.DS_Store

--- a/textext/asktext.py
+++ b/textext/asktext.py
@@ -626,7 +626,7 @@ class AskTextGTKSource(AskText):
                 {new_node_content}
               </menu>
               <menu action='CloseShortcut'>
-                {close_shortcut} 
+                {close_shortcut}
               </menu>
               <menuitem action='ConfirmClose'/>
             </menu>
@@ -1270,7 +1270,10 @@ class AskTextGTKSource(AskText):
                 iter = self._source_buffer.get_iter_at_offset(1)
                 self._source_buffer.place_cursor(iter)
             if new_node_content_value=='DisplayMath':
-                self.text = "$$$$"
+                if self.current_texcmd == "typst":
+                    self.text = "$  $"
+                else:
+                    self.text = "$$$$"
                 self._source_buffer.set_text(self.text)
                 iter = self._source_buffer.get_iter_at_offset(2)
                 self._source_buffer.place_cursor(iter)


### PR DESCRIPTION
Related issue(s):https://github.com/textext/textext/issues/417

Precise description of the changes proposed in the pull request:

In typst, the display math is marked as `$ Formula $`.

This pull changes the build-in text if user is using Typst.

Short checklist:
- [x] Tested with Inkscape version: [1.3.2]
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [x] Tested on MacOS, Version:  [Ventura 13.5 (22G74)]
