### PR TITLE
Added Option to customize Latex Command Line Options

### DIFF
--- a/textext/LATEX_OPTIONS
+++ b/textext/LATEX_OPTIONS
@@ -1,0 +1,2 @@
+-interaction=nonstopmode
+-halt-on-error


### PR DESCRIPTION
### Customizable Latex Options

**Background.** I have been trying to use the latex [minted](https://ctan.org/pkg/minted?lang=en) package for syntax highlighting together with the ``textext`` plugin. The package works, but requires the ``-escape-shell`` option to be set for the latex executable.

**Changes.** Since the ``-escape-shell`` option probably does not make sense as a default and others might want to customize the latex options differently in the future, I added a way to customize the options without modifying the code.

I added a file ``LATEX_OPTIONS`` to the ``textext`` plugin folder. Each line in this file represents one option given to the latex executable. This options file is loaded in the constructor of the ``TexToPdfConverter`` class to overwrite the default values in the ``TexToPdfConverter.LATEX_OPTIONS`` list - only if the file exists (should be fully backward compatible).

While using the ``-escape-shell`` option, I noticed that it is only properly recognized when the option is given before the name of the latex file. So it should be

```sh
pdflatex -escape-shell input.tex
```

and not

```sh
pdflatex input.tex -escape-shell
```

This is why I also had to change a section of the ``TexToPdfConverter.tex_to_pdf`` method that was previously like this:

```python
command = [tex_command, self.tmp('tex')] + self.LATEX_OPTIONS
exec_command(command)
```

to now be like this:

```python
command = [tex_command, *self.LATEX_OPTIONS, self.tmp('tex')]
exec_command(command)
```

Please let me know if you agree with this implementation of option customization or if you'd solve the problem differently. 

---

Related issue(s): ---

Short checklist:
- [x] Tested with Inkscape version: 1.3
- [x] Tested on Linux, Distro: Ubuntu 22.04
- [x] Tested on Windows, Version: [not available]
- [ ] Tested on MacOS, Version:  [not available]
