### PR TITLE
Add typst preamble support

### DIFF
--- a/textext/asktext.py
+++ b/textext/asktext.py
@@ -438,9 +438,8 @@ class AskTextTK(AskText):
         self._gui_config["word_wrap"] = self._word_wrap_tkval.get()
 
     def on_texcmd_change(self):
-        using_tex = self._tex_command_tk_str.get() != "typst"
-        self._preamble["state"] = Tk.NORMAL if using_tex else Tk.DISABLED
-        self._askfilename_button["state"] = Tk.NORMAL if using_tex else Tk.DISABLED
+        self._preamble["state"] = Tk.NORMAL
+        self._askfilename_button["state"] = Tk.NORMAL
 
     def reset_scale_factor(self, _=None):
         self._scale.delete(0, "end")
@@ -819,10 +818,7 @@ class AskTextGTKSource(AskText):
         self.window_deleted_cb(widget, None, None)
 
     def cb_compiler_changed(self, combo_box):
-        using_tex = self.TEX_COMMANDS[self._texcmd_cbox.get_active()] != "typst"
-        self._preview_button.set_sensitive(using_tex)
-        self._preamble_widget.set_sensitive(using_tex)
-        self._preamble_delete_btn.set_sensitive(using_tex)
+        pass
 
     def move_cursor_cb(self, text_buffer, cursoriter, mark, view):
         self.update_position_label(text_buffer, self, view)

--- a/textext/base.py
+++ b/textext/base.py
@@ -599,27 +599,19 @@ class TexToPdfConverter:
         """
 
         with logger.debug("Converting .typ to .{0}".format(file_type)):
-            # # Read preamble
-            # preamble_file = os.path.abspath(preamble_file)
-            # preamble = ""
-            #
-            # if os.path.isfile(preamble_file):
-            #     with open(preamble_file, 'r') as f:
-            #         preamble += f.read()
-            #
-            # # Add default document class to preamble if necessary
-            # if not _contains_document_class(preamble):
-            #     preamble = self.DEFAULT_DOCUMENT_CLASS + preamble
-            #
-            # # Options pass to LaTeX-related commands
-            #
-            # texwrapper = self.DOCUMENT_TEMPLATE % (preamble, latex_text)
-
+            # Read preamble
+            preamble_file = os.path.abspath(preamble_file)
+            preamble = ""
+            
+            if os.path.isfile(preamble_file):
+                with open(preamble_file, 'r') as f:
+                    preamble += f.read()
+            
             # Convert Typ to PDF
 
             # Write tex
             with open(self.tmp('typ'), mode='w', encoding='utf-8') as f_typ:
-                f_typ.write(f"#set page(fill:none)\n\n{typst_text}")
+                f_typ.write(f"{preamble}\n\n#set page(fill:none)\n\n{typst_text}")
 
             # Exec tex_command: tex -> pdf
             try:


### PR DESCRIPTION
Thanks for this plugin, it makes making nice looking figures so much easier :heart: 

I was very happy to see typst support was added, and for my use case, I'd really like preamble support. I'm not sure if there is a reason for it being disabled before, but this system seems to just work for me at least

Followup to #403 I suppose

Short checklist:
- [x] Tested with Inkscape version: [1.4.1]
- [x] Tested on Linux, Distro: [Arch Linux]
- [ ] Tested on Windows, Version: [N/A]
- [ ] Tested on MacOS, Version:  [N/A]

I don't have easy access to windows or macos systems to test with
