### PR TITLE
Avoid trouble in paradoxical configurations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ def remove_previous_installation(extension_dir):
     ]
     for file_or_dir in previous_installation_files_and_folders:
         file_or_dir = os.path.abspath(os.path.join(extension_dir, file_or_dir))
-        if os.path.isfile(file_or_dir):
+        if os.path.isfile(file_or_dir) or os.path.islink(file_or_dir):
             logger.info("Removing `%s`" % file_or_dir)
             os.remove(file_or_dir)
         elif os.path.isdir(file_or_dir):
@@ -481,10 +481,13 @@ if __name__ == "__main__":
                            rel_filenames=files_to_keep,
                            tmp_dir=tmp_dir
                            ):
+            source_path = os.path.dirname(os.path.abspath(__file__))
+            if os.path.dirname(source_path) == args.inkscape_extensions_path:
+                logger.error("Can't install extension from itself")
+                exit(EXIT_BAD_COMMAND_LINE_ARGUMENT_VALUE)
             remove_previous_installation(args.inkscape_extensions_path)
-
             copy_extension_files(
-                src=os.path.join(os.path.dirname(os.path.abspath(__file__)), "textext"),
+                src=os.path.join(source_path, "textext"),
                 dst=args.inkscape_extensions_path,
                 if_already_exists="overwrite"
             )


### PR DESCRIPTION
There are two cases where `python setup.py` would previously cause trouble:

1. when the user `git clone` into `~/.config/inkscape/extensions/textext` itself. Then `python setup.py` would wipe the git repository.
2. when `~/.config/inkscape/extensions/textext` is a symbolic link. Then `shutil.rmtree` would raise

```
Traceback (most recent call last):
  File ".../textext/setup.py", line 488, in <module>
    remove_previous_installation(args.inkscape_extensions_path)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../textext/setup.py", line 218, in remove_previous_installation
    shutil.rmtree(file_or_dir)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/shutil.py", line 763, in rmtree
    _rmtree_safe_fd(stack, onexc)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/shutil.py", line 707, in _rmtree_safe_fd
    onexc(func, path, err)
    ~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/shutil.py", line 676, in _rmtree_safe_fd
    raise OSError("Cannot call rmtree on a symbolic link")
OSError: [Errno None] None: '.../.config/inkscape/extensions/textext'
```

Short checklist:
- [x] Tested with Inkscape version: 1.4
- [x] Tested on Linux, Distro: Arch
- [x] Tested on Windows, Version: 11 23H2
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
