### PR TITLE
Show traceback in error dialog

### DIFF
--- a/textext/asktext.py
+++ b/textext/asktext.py
@@ -38,6 +38,7 @@ TOOLKIT = None
 import os
 import sys
 import warnings
+import traceback
 from .errors import TexTextCommandFailed
 from textext.utility import SuppressStream
 
@@ -509,6 +510,8 @@ class AskTextTK(AskText):
 
             if exception.stderr:
                 add_textview('Stderr:', exception.stderr.decode('utf-8'))
+
+        add_textview('Traceback:', '\n'.join(traceback.format_exception(exception)))
 
         close_button = Tk.Button(err_dialog, text='OK', command=close_error_dialog)
         close_button.pack(side='top', fill='x', expand=True)
@@ -1392,6 +1395,9 @@ class AskTextGTKSource(AskText):
                 add_section("Stdout: <small><i>(click to expand)</i></small>", exception.stdout.decode('utf-8'))
             if exception.stderr:
                 add_section("Stderr: <small><i>(click to expand)</i></small>", exception.stderr.decode('utf-8'))
+
+        add_section("Traceback: <small><i>(click to expand)</i></small>", '\n'.join(traceback.format_exception(exception)))
+
         dialog.show_all()
         dialog.run()
 


### PR DESCRIPTION
As in the title. This makes debugging easier if some error happens.

By the way, what is the https://github.com/textext/textext/tree/TEXTEXT_2_0_Dev branch?

Short checklist:
- [ ] Tested with Inkscape version: [fill in Inkscape version here]
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
