### PR TITLE
Unique IDs also in children

### DIFF
--- a/textext/base.py
+++ b/textext/base.py
@@ -744,32 +744,10 @@ class TexTextElement(inkex.Group):
     def make_ids_unique(self):
         """
         PDF->SVG converters tend to use same ids.
-        To avoid confusion between objects with same id from two or more TexText objects we replace auto-generated
-        ids with random unique values
+        To avoid confusion between objects with same id from two or more TexText objects we replace
+        auto-generated ids from the converter with random unique values
         """
-        rename_map = {}
-
-        # replace all ids with unique random uuid
-        for el in self.iterfind('.//*[@id]'):
-            old_id = el.attrib["id"]
-            new_id = 'id-' + str(uuid.uuid4())
-            el.attrib["id"] = new_id
-            rename_map[old_id] = new_id
-
-        # find usages of old ids and replace them
-        def replace_old_id(m):
-            old_name = m.group(1)
-            try:
-                replacement = rename_map[old_name]
-            except KeyError:
-                replacement = old_name
-            return "url(#{})".format(replacement)
-        regex = re.compile(r"url\(#([^)(]*)\)")
-
-        for el in self.iter():
-            for name, value in el.items():
-                new_value = regex.sub(replace_old_id, value)
-                el.attrib[name] = new_value
+        self.set_random_ids(prefix=None, levels=-1, backlinks=True)
 
     def get_jacobian_sqrt(self):
         from inkex import Transform


### PR DESCRIPTION
Using inkex API to set unique IDs for the node and also its children. Ensures that
the old node is still selected completely after TexText closes, see #460.

Resolves #460

@user202729 I think this fixes the problem. If you have the time, you may test it.

Short checklist:
- [x] Tested with Inkscape version: 1.4.0
- [x] Tested on Linux, Kubuntu 24.04
- [x] Tested on Windows, Version: 11 23H2
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
