### PR TITLE
Avoid bringing replaced node to front

### DIFF
--- a/textext/base.py
+++ b/textext/base.py
@@ -494,9 +494,9 @@ class TexText(inkex.EffectExtension):
         Replace an XML node old_node with new_node
         """
         parent = old_node.getparent()
+        index = parent.index(old_node)
         old_id = old_node.get_id()
-        parent.remove(old_node)
-        parent.append(new_node)
+        parent[index] = new_node
         new_node.set_id(old_id)
         self.copy_style(old_node, new_node)
 


### PR DESCRIPTION
If originally there's a textext node A and another shape B, the original code will always bring A to front after each edit. This will not do that.

Mostly affect the case where the textext node A is something like using tikz to draw a grid and there are some other elements in front of it. Actual texts are often not covered.

Short checklist:
- [x] Tested with Inkscape version: 1.4.1
- [x] Tested on Linux, Distro: Arch
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
