### PR TITLE
Fix Gtk warning

### DIFF
--- a/textext/asktext.py
+++ b/textext/asktext.py
@@ -1331,7 +1331,7 @@ def load_asktext_gtk(use_gtk_source=None):
 
         def show_error_dialog(self, title, message_text, exception):
 
-            dialog = Gtk.Dialog(title, self._window)
+            dialog = Gtk.Dialog(title=title, transient_for=self._window)
             dialog.set_default_size(450, 300)
             button = dialog.add_button(Gtk.STOCK_OK, Gtk.ResponseType.CLOSE)
             button.connect("clicked", lambda w, d=None: dialog.destroy())


### PR DESCRIPTION
Fixes https://github.com/textext/textext/issues/473



Short checklist:
- [ ] Tested with Inkscape version: [fill in Inkscape version here]
- [ ] Tested on Linux, Distro: [fill in distribution name here]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
