### PR TITLE
Suppress gi deprecation warnings leaking to stderr (fixes #496)

### DIFF
--- a/textext/asktext.py
+++ b/textext/asktext.py
@@ -463,6 +463,21 @@ def load_asktext_gtk(use_gtk_source=None):
     import gi
     gi.require_version("Gtk", "3.0")
 
+    # Inkscape shows a spurious "Inkscape has received additional data from the
+    # script executed" dialog whenever an extension writes ANYTHING to stderr -
+    # even a harmless warning on a clean exit. On newer PyGObject (Python 3.12+,
+    # e.g. Ubuntu 26.04) the gi.repository imports below emit a
+    # PyGIDeprecationWarning to stderr at override-load time, e.g. "GLib.
+    # unix_signal_add_full is deprecated; use GLibUnix.signal_add_full instead".
+    # Ignoring the whole category here - before those imports, which is where it
+    # fires - keeps every current and future gi deprecation warning out of the
+    # stderr Inkscape inspects (this also covers the Gtk.Dialog case patched
+    # piecemeal in #475). See #496.
+    warnings.filterwarnings(
+        "ignore",
+        category=getattr(gi, "PyGIDeprecationWarning", DeprecationWarning),
+    )
+
     # The import statement
     # from gi.repository import Gtk
     # writes a warning into stderr under Python 3.10 which always pops up after the


### PR DESCRIPTION
**Related issue(s):** #496, #473 (closed), #322 (closed), #250 (closed) — all the "Inkscape has received additional data from the script executed" dialog caused by a gi/Gtk deprecation warning leaking to stderr. #473 was addressed piecemeal by #475; this change generalizes that fix.

On newer PyGObject (Python 3.12+, e.g. Ubuntu 26.04 with GLib ≥ 2.88), the `from gi.repository import …` statements in `load_asktext_gtk()` emit a `PyGIDeprecationWarning` to stderr at override-load time — e.g. *"GLib.unix_signal_add_full is deprecated; use GLibUnix.signal_add_full instead"*. Inkscape treats **any** non-empty stderr from an extension as "additional data" and shows the *"Inkscape has received additional data from the script executed"* dialog on every TexText run, even though the extension exits cleanly and the node renders correctly.

This adds a single `warnings.filterwarnings("ignore", category=PyGIDeprecationWarning)` in `load_asktext_gtk()`, **before** the `gi.repository` imports (where the warning fires). Filtering the whole category — rather than one message string — keeps every current and future gi deprecation warning out of the stderr Inkscape inspects, and subsumes the `Gtk.Dialog` case fixed piecemeal in #475. The category is resolved via `getattr(gi, "PyGIDeprecationWarning", DeprecationWarning)` so it degrades safely on any PyGObject. The change is confined to the GTK path (Tk path untouched) and has no functional effect beyond suppressing advisory deprecation notices — consistent with the existing `warnings.filterwarnings("ignore", category=DeprecationWarning)` in `ask()`.

Short checklist:
- [x] Tested with Inkscape version: 1.4.4 (PPA inkscape.dev/stable)
- [x] Tested on Linux, Distro: Ubuntu 26.04 (reproduces the dialog → fixed by this change) and Ubuntu 25.10 (older GLib 2.86 — dialog does not fire; verified no regression, plus a headless check that the category filter suppresses the warning on that stack)
- [ ] Tested on Windows, Version: not tested — change is GTK-path only and a no-op where the warning does not fire
- [ ] Tested on MacOS, Version: not tested — Tk path unaffected; GTK-path-only change
